### PR TITLE
Fix issue with master example when viewer is already connected

### DIFF
--- a/examples/master.js
+++ b/examples/master.js
@@ -100,16 +100,16 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
         audio: formValues.sendAudio,
     };
 
+    // Get a stream from the webcam and display it in the local view
+    try {
+        master.localStream = await navigator.mediaDevices.getUserMedia(constraints);
+        localView.srcObject = master.localStream;
+    } catch (e) {
+        console.error('[MASTER] Could not find webcam');
+    }
+
     master.signalingClient.on('open', async () => {
         console.log('[MASTER] Connected to signaling service');
-
-        // Get a stream from the webcam and display it in the local view
-        try {
-            master.localStream = await navigator.mediaDevices.getUserMedia(constraints);
-            localView.srcObject = master.localStream;
-        } catch (e) {
-            console.error('[MASTER] Could not find webcam');
-        }
     });
 
     master.signalingClient.on('sdpOffer', async (offer, remoteClientId) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7264,12 +7264,6 @@
                 }
             }
         },
-        "serialize-javascript": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
-            "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==",
-            "dev": true
-        },
         "serve-index": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
@@ -8036,9 +8030,9 @@
             }
         },
         "terser": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-4.4.2.tgz",
-            "integrity": "sha512-Uufrsvhj9O1ikwgITGsZ5EZS6qPokUOkCegS7fYOdGTv+OA90vndUbU6PEjr5ePqHfNUbGyMO7xyIZv2MhsALQ==",
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.1.tgz",
+            "integrity": "sha512-w0f2OWFD7ka3zwetgVAhNMeyzEbj39ht2Tb0qKflw9PmW9Qbo5tjTh01QJLkhO9t9RDDQYvk+WXqpECI2C6i2A==",
             "dev": true,
             "requires": {
                 "commander": "^2.20.0",
@@ -8055,22 +8049,28 @@
             }
         },
         "terser-webpack-plugin": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
-            "integrity": "sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==",
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
+            "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
             "dev": true,
             "requires": {
                 "cacache": "^12.0.2",
                 "find-cache-dir": "^2.1.0",
                 "is-wsl": "^1.1.0",
                 "schema-utils": "^1.0.0",
-                "serialize-javascript": "^1.7.0",
+                "serialize-javascript": "^2.1.2",
                 "source-map": "^0.6.1",
                 "terser": "^4.1.2",
                 "webpack-sources": "^1.4.0",
                 "worker-farm": "^1.7.0"
             },
             "dependencies": {
+                "serialize-javascript": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+                    "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
+                    "dev": true
+                },
                 "source-map": {
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -8411,6 +8411,7 @@
             "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.1.tgz",
             "integrity": "sha512-pnOF7jY82wdIhATVn87uUY/FHU+MDUdPLkmGFvGoclQmeu229eTkbG5gjGGBi3R7UuYYSEeYXY/TTY5j2aym2g==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "commander": "~2.20.3",
                 "source-map": "~0.6.1"
@@ -8420,32 +8421,8 @@
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
                     "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                }
-            }
-        },
-        "uglifyjs-webpack-plugin": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-2.2.0.tgz",
-            "integrity": "sha512-mHSkufBmBuJ+KHQhv5H0MXijtsoA1lynJt1lXOaotja8/I0pR4L9oGaPIZw+bQBOFittXZg9OC1sXSGO9D9ZYg==",
-            "dev": true,
-            "requires": {
-                "cacache": "^12.0.2",
-                "find-cache-dir": "^2.1.0",
-                "is-wsl": "^1.1.0",
-                "schema-utils": "^1.0.0",
-                "serialize-javascript": "^1.7.0",
-                "source-map": "^0.6.1",
-                "uglify-js": "^3.6.0",
-                "webpack-sources": "^1.4.0",
-                "worker-farm": "^1.7.0"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "amazon-kinesis-video-streams-webrtc",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
         "ts-jest": "^24.2.0",
         "ts-loader": "^6.0.4",
         "typescript": "^3.6.2",
-        "uglifyjs-webpack-plugin": "^2.2.0",
         "webpack": "^4.39.3",
         "webpack-cli": "^3.3.7",
         "webpack-dev-server": "^3.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "amazon-kinesis-video-streams-webrtc",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Amazon Kinesis Video Streams WebRTC SDK for JavaScript.",
     "repository": {
         "type": "git",


### PR DESCRIPTION
In the master example, initialize the webcam before connecting to the channel to ensure that if a remote SDP offer from a viewer is pending in the channel, an SDP answer can be created.

This issue was easily reproducible by starting a viewer and then starting a master in on the JS SDK test page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
