### PR TITLE
Add explicit dependency on tslib because TypeScript build outputs depend on it.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8336,8 +8336,7 @@
         "tslib": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-            "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-            "dev": true
+            "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
         },
         "tsutils": {
             "version": "3.17.1",

--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
         "webpack-cli": "^3.3.7",
         "webpack-dev-server": "^3.8.0",
         "webpack-merge": "^4.2.2"
+    },
+    "dependencies": {
+        "tslib": "^1.10.0"
     }
 }


### PR DESCRIPTION
*Description of changes:*
Add explicit dependency on [tslib](https://www.npmjs.com/package/tslib).

This issue was reported:
```
{
  "errorType": "Runtime.ImportModuleError",
  "errorMessage": "Error: Cannot find module 'tslib'\nRequire stack:\n- /var/task/node_modules/amazon-kinesis-video-streams-webrtc/lib/SignalingClient.js\n- /var/task/node_modules/amazon-kinesis-video-streams-webrtc/lib/index.js\n- /var/task/index.js\n- /var/runtime/UserFunction.js\n- /var/runtime/index.js",
  "trace": [
    "Runtime.ImportModuleError: Error: Cannot find module 'tslib'",
    "Require stack:",
...
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
