### PR TITLE
Add dependency on 'isomorphic-webcrypto'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1190,6 +1190,56 @@
                 "@types/yargs": "^13.0.0"
             }
         },
+        "@peculiar/asn1-schema": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-1.1.2.tgz",
+            "integrity": "sha512-ntQ4UnUFgdjs0tfWR6YmEQm/x0glV4OFus/RjxLkaJUKfu/R7VilefBntyUO3MoKWdlCgib30KN+JpCY1HqU2A==",
+            "requires": {
+                "asn1js": "^2.0.26",
+                "tslib": "^1.11.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.11.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+                    "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+                }
+            }
+        },
+        "@peculiar/json-schema": {
+            "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.10.tgz",
+            "integrity": "sha512-kbpnG9CkF1y6wwGkW7YtSA+yYK4X5uk4rAwsd1hxiaYE3Hkw2EsGlbGh/COkMLyFf+Fe830BoFiMSB3QnC/ItA==",
+            "requires": {
+                "tslib": "^1.11.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.11.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+                    "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+                }
+            }
+        },
+        "@peculiar/webcrypto": {
+            "version": "1.0.29",
+            "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.0.29.tgz",
+            "integrity": "sha512-3e6CIpjZuj5WxPymGm0kCZA05XA9BSXwBEb/mU9KjBHAmEwMokT0yVIhxqwspCHSynlrTfUB+9KTNpseyB077A==",
+            "requires": {
+                "@peculiar/asn1-schema": "^1.1.2",
+                "@peculiar/json-schema": "^1.1.10",
+                "pvtsutils": "^1.0.10",
+                "tslib": "^1.11.1",
+                "webcrypto-core": "^1.0.20"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.11.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+                    "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+                }
+            }
+        },
         "@sinonjs/commons": {
             "version": "1.7.1",
             "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
@@ -1452,6 +1502,26 @@
                 "lodash.unescape": "4.0.1",
                 "semver": "^6.3.0",
                 "tsutils": "^3.17.1"
+            }
+        },
+        "@unimodules/core": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@unimodules/core/-/core-5.1.0.tgz",
+            "integrity": "sha512-gaamGkJ4PVwusWEfsZyPo4uhrVWPDE0BmHc/lTYfkZCv2oIAswC7gG/ULRdtZpYdwnYqFIZng+WQxwuVrJUNDw==",
+            "optional": true,
+            "requires": {
+                "compare-versions": "^3.4.0"
+            }
+        },
+        "@unimodules/react-native-adapter": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@unimodules/react-native-adapter/-/react-native-adapter-5.2.0.tgz",
+            "integrity": "sha512-S3HMEeQbV6xs7ORRcxXFGMk38DAnxqNcZG9T8JkX/KGY9ILUUqTS/e68+d849B6beEeglNMcOxyjwlqjykN+FA==",
+            "optional": true,
+            "requires": {
+                "invariant": "^2.2.4",
+                "lodash": "^4.5.0",
+                "prop-types": "^15.6.1"
             }
         },
         "@webassemblyjs/ast": {
@@ -1856,6 +1926,11 @@
             "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
             "dev": true
         },
+        "asmcrypto.js": {
+            "version": "0.22.0",
+            "resolved": "https://registry.npmjs.org/asmcrypto.js/-/asmcrypto.js-0.22.0.tgz",
+            "integrity": "sha512-usgMoyXjMbx/ZPdzTSXExhMPur2FTdz/Vo5PVx2gIaBcdAAJNOFlsdgqveM8Cff7W0v+xrf9BwjOV26JSAF9qA=="
+        },
         "asn1": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
@@ -1871,6 +1946,14 @@
                 "bn.js": "^4.0.0",
                 "inherits": "^2.0.1",
                 "minimalistic-assert": "^1.0.0"
+            }
+        },
+        "asn1js": {
+            "version": "2.0.26",
+            "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.0.26.tgz",
+            "integrity": "sha512-yG89F0j9B4B0MKIcFyWWxnpZPLaNTjCj4tkE3fjbAoo0qmpGw0PYYqSbX/4ebnd9Icn8ZgK4K1fvDyEtW1JYtQ==",
+            "requires": {
+                "pvutils": "^1.0.17"
             }
         },
         "assert": {
@@ -1962,6 +2045,22 @@
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
             "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
             "dev": true
+        },
+        "b64-lite": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/b64-lite/-/b64-lite-1.4.0.tgz",
+            "integrity": "sha512-aHe97M7DXt+dkpa8fHlCcm1CnskAHrJqEfMI0KN7dwqlzml/aUe1AGt6lk51HzrSfVD67xOso84sOpr+0wIe2w==",
+            "requires": {
+                "base-64": "^0.1.0"
+            }
+        },
+        "b64u-lite": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/b64u-lite/-/b64u-lite-1.1.0.tgz",
+            "integrity": "sha512-929qWGDVCRph7gQVTC6koHqQIpF4vtVaSbwLltFQo44B1bYUquALswZdBKFfrJCPEnsCOvWkJsPdQYZ/Ukhw8A==",
+            "requires": {
+                "b64-lite": "^1.4.0"
+            }
         },
         "babel-code-frame": {
             "version": "6.26.0",
@@ -2204,11 +2303,15 @@
                 }
             }
         },
+        "base-64": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
+            "integrity": "sha1-eAqZyE59YAJgNhURxId2E78k9rs="
+        },
         "base64-js": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-            "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-            "dev": true
+            "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
         },
         "base64url": {
             "version": "3.0.1",
@@ -2832,6 +2935,12 @@
             "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
             "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
             "dev": true
+        },
+        "compare-versions": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
+            "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
+            "optional": true
         },
         "component-emitter": {
             "version": "1.3.0",
@@ -3861,6 +3970,15 @@
                         "has-flag": "^4.0.0"
                     }
                 }
+            }
+        },
+        "expo-random": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/expo-random/-/expo-random-8.1.0.tgz",
+            "integrity": "sha512-9n2gg83Hpg3ErkKu+a3FFOGmaPIxaHn6RuzjW24xFckdfmnrAKtbs1aU1aAcmoL1kXPvDeufRSEV/3lW93u6ug==",
+            "optional": true,
+            "requires": {
+                "base64-js": "^1.3.0"
             }
         },
         "express": {
@@ -5447,6 +5565,15 @@
             "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
             "dev": true
         },
+        "invariant": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+            "optional": true,
+            "requires": {
+                "loose-envify": "^1.0.0"
+            }
+        },
         "invert-kv": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
@@ -5729,6 +5856,24 @@
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
             "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
             "dev": true
+        },
+        "isomorphic-webcrypto": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/isomorphic-webcrypto/-/isomorphic-webcrypto-2.3.6.tgz",
+            "integrity": "sha512-d1prB3b0UMWOao5DK3+O2Dr5ZJCakzB5Q+2kCWNkNuM9ln7VB8TSw2SwUjbnErzg7cgsYja+VPQaeBtXEojpew==",
+            "requires": {
+                "@peculiar/webcrypto": "^1.0.22",
+                "@unimodules/core": "*",
+                "@unimodules/react-native-adapter": "*",
+                "asmcrypto.js": "^0.22.0",
+                "b64-lite": "^1.3.1",
+                "b64u-lite": "^1.0.1",
+                "expo-random": "*",
+                "msrcrypto": "^1.5.6",
+                "react-native-securerandom": "^0.1.1",
+                "str2buf": "^1.3.0",
+                "webcrypto-shim": "^0.1.4"
+            }
         },
         "isstream": {
             "version": "0.1.2",
@@ -8193,8 +8338,7 @@
         "js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "dev": true
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "js-yaml": {
             "version": "3.13.1",
@@ -8417,8 +8561,7 @@
         "lodash": {
             "version": "4.17.15",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-            "dev": true
+            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         },
         "lodash.memoize": {
             "version": "4.1.2",
@@ -8451,6 +8594,15 @@
             "dev": true,
             "requires": {
                 "@sinonjs/commons": "^1.7.0"
+            }
+        },
+        "loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "optional": true,
+            "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
             }
         },
         "lru-cache": {
@@ -8746,6 +8898,11 @@
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true
         },
+        "msrcrypto": {
+            "version": "1.5.8",
+            "resolved": "https://registry.npmjs.org/msrcrypto/-/msrcrypto-1.5.8.tgz",
+            "integrity": "sha512-ujZ0TRuozHKKm6eGbKHfXef7f+esIhEckmThVnz7RNyiOJd7a6MXj2JGBoL9cnPDW+JMG16MoTUh5X+XXjI66Q=="
+        },
         "multicast-dns": {
             "version": "6.2.3",
             "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
@@ -8949,8 +9106,7 @@
         "object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-            "dev": true
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "object-copy": {
             "version": "0.1.0",
@@ -9486,6 +9642,17 @@
                 "sisteransi": "^1.0.4"
             }
         },
+        "prop-types": {
+            "version": "15.7.2",
+            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+            "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+            "optional": true,
+            "requires": {
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.8.1"
+            }
+        },
         "proxy-addr": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -9561,6 +9728,19 @@
             "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
             "dev": true
         },
+        "pvtsutils": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.0.10.tgz",
+            "integrity": "sha512-8ZKQcxnZKTn+fpDh7wL4yKax5fdl3UJzT8Jv49djZpB/dzPxacyN1Sez90b6YLdOmvIr9vaySJ5gw4aUA1EdSw==",
+            "requires": {
+                "tslib": "^1.10.0"
+            }
+        },
+        "pvutils": {
+            "version": "1.0.17",
+            "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.0.17.tgz",
+            "integrity": "sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ=="
+        },
         "qs": {
             "version": "6.5.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -9633,8 +9813,16 @@
         "react-is": {
             "version": "16.12.0",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
-            "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==",
-            "dev": true
+            "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
+        },
+        "react-native-securerandom": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/react-native-securerandom/-/react-native-securerandom-0.1.1.tgz",
+            "integrity": "sha1-8TBiOkEsM4sK+t7bwgTFy7i/IHA=",
+            "optional": true,
+            "requires": {
+                "base64-js": "*"
+            }
         },
         "readable-stream": {
             "version": "2.3.6",
@@ -10583,6 +10771,11 @@
             "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
             "dev": true
         },
+        "str2buf": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/str2buf/-/str2buf-1.3.0.tgz",
+            "integrity": "sha512-xIBmHIUHYZDP4HyoXGHYNVmxlXLXDrtFHYT0eV6IOdEj3VO9ccaF1Ejl9Oq8iFjITllpT8FhaXb4KsNmw+3EuA=="
+        },
         "stream-browserify": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
@@ -11523,6 +11716,30 @@
             "requires": {
                 "minimalistic-assert": "^1.0.0"
             }
+        },
+        "webcrypto-core": {
+            "version": "1.0.21",
+            "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.0.21.tgz",
+            "integrity": "sha512-PcSD8Ga3u344LXEcI/1UbGv3dv5rZ8pzkeJIrMf/JOnEq8H5hSMmdTrRIp2WFYYnMNdKQbP564v560ZmERT2HQ==",
+            "requires": {
+                "@peculiar/asn1-schema": "^1.1.2",
+                "@peculiar/json-schema": "^1.1.10",
+                "asn1js": "^2.0.26",
+                "pvtsutils": "^1.0.10",
+                "tslib": "^1.11.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.11.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+                    "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+                }
+            }
+        },
+        "webcrypto-shim": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/webcrypto-shim/-/webcrypto-shim-0.1.5.tgz",
+            "integrity": "sha512-mE+E00gulvbLjHaAwl0kph60oOLQRsKyivEFgV9DMM/3Y05F1vZvGq12hAcNzHRnYxyEOABBT/XMtwGSg5xA7A=="
         },
         "webidl-conversions": {
             "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
         "webpack-merge": "^4.2.2"
     },
     "dependencies": {
+        "isomorphic-webcrypto": "^2.3.6",
         "tslib": "^1.10.0"
     }
 }

--- a/src/SigV4RequestSigner.spec.ts
+++ b/src/SigV4RequestSigner.spec.ts
@@ -1,5 +1,3 @@
-import crypto from '@trust/webcrypto';
-
 import { SigV4RequestSigner } from './SigV4RequestSigner';
 import { Credentials, QueryParams } from './SignalingClient';
 
@@ -9,10 +7,6 @@ describe('SigV4RequestSigner', () => {
     let signer: SigV4RequestSigner;
     let queryParams: QueryParams;
     let date: Date;
-
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
-    global.crypto = crypto;
 
     beforeEach(() => {
         region = 'us-west-2';

--- a/src/SigV4RequestSigner.ts
+++ b/src/SigV4RequestSigner.ts
@@ -1,5 +1,8 @@
+import crypto from 'isomorphic-webcrypto';
+
 import { Credentials, QueryParams, RequestSigner } from './SignalingClient';
 import { validateValueNonNil } from './internal/utils';
+
 type Headers = { [header: string]: string };
 
 /**

--- a/src/typings/isomorphic-crypto/index.d.ts
+++ b/src/typings/isomorphic-crypto/index.d.ts
@@ -1,4 +1,0 @@
-declare module 'isomorphic-cryptso' {
-    const crypto: Crypto;
-    export default crypto;
-}

--- a/src/typings/isomorphic-crypto/index.d.ts
+++ b/src/typings/isomorphic-crypto/index.d.ts
@@ -1,0 +1,4 @@
+declare module 'isomorphic-cryptso' {
+    const crypto: Crypto;
+    export default crypto;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     "noImplicitThis": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "removeComments": false
+    "removeComments": false,
+    "skipLibCheck": true
   },
   "formatCodeOptions": {
     "indentSize": 4,
@@ -31,5 +32,8 @@
   ],
   "include": [
     "src/typings/**/*"
+  ],
+  "exclude": [
+    "node_modules/isomorphic-webcrypto/index.d.ts"
   ]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,9 @@ module.exports = {
         library: 'KVSWebRTC',
         libraryTarget: 'window',
     },
+    externals: {
+        'isomorphic-webcrypto': 'crypto',
+    },
     resolve: {
         extensions: ['.ts', '.js'],
     },


### PR DESCRIPTION
Add dependency on [`isomorphic-webcrypto`](https://github.com/kevlened/isomorphic-webcrypto) to support NodeJS and React Native environments.

*Issue #, if available:*
Also should accomplish the same as https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/pull/26

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
