### PR TITLE
Correct parameter type for isomorphic-webcrypto

### DIFF
--- a/src/SigV4RequestSigner.ts
+++ b/src/SigV4RequestSigner.ts
@@ -189,7 +189,7 @@ export class SigV4RequestSigner implements RequestSigner {
             false,
             ['sign'],
         );
-        return await crypto.subtle.sign({ name: 'HMAC' }, cryptoKey, messageBuffer);
+        return await crypto.subtle.sign({ name: 'HMAC', hash: { name: 'SHA-256' } }, cryptoKey, messageBuffer);
     }
 
     /**

--- a/src/SigV4RequestSigner.ts
+++ b/src/SigV4RequestSigner.ts
@@ -189,7 +189,7 @@ export class SigV4RequestSigner implements RequestSigner {
             false,
             ['sign'],
         );
-        return await crypto.subtle.sign('HMAC', cryptoKey, messageBuffer);
+        return await crypto.subtle.sign({ name: 'HMAC' }, cryptoKey, messageBuffer);
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:*
Althought React Native support was added, it was not working as intended, as the sign call was not made in correspondence with something that worked with the Microsoft Research Library. More specifically, the expected parameters for HMAC signing is an object specifying properties with name and hash name, and this was not provided, causing it to error out with the error that the parameter was not the expected type from [the parameter checker](https://github.com/kevlened/msrCrypto/blob/5fe8c44093e5f3b799079e3c8fda252b6edab44f/msrcrypto.js#L9116)

*Description of changes:*
By changing over to the proper parameter type, i.e. an object specifying both the name and the hashing method, there are no more signing errors, and the library works as intended on React Native.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
