### PR TITLE
Fix an error flow when datachannel only mode

### DIFF
--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -110,14 +110,18 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, onR
     viewer.signalingClient.on('open', async () => {
         console.log('[VIEWER] Connected to signaling service');
 
-        // Get a stream from the webcam, add it to the peer connection, and display it in the local view
-        try {
-            viewer.localStream = await navigator.mediaDevices.getUserMedia(constraints);
-            viewer.localStream.getTracks().forEach(track => viewer.peerConnection.addTrack(track, viewer.localStream));
-            localView.srcObject = viewer.localStream;
-        } catch (e) {
-            console.error('[VIEWER] Could not find webcam');
-            return;
+        // Get a stream from the webcam, add it to the peer connection, and display it in the local view.
+        // If no video/audio needed, no need to request for the sources. 
+        // Otherwise, the browser will throw an error saying that either video or audio has to be enabled.
+        if (formValues.sendVideo || formValues.sendAudio) {
+            try {
+                viewer.localStream = await navigator.mediaDevices.getUserMedia(constraints);
+                viewer.localStream.getTracks().forEach(track => viewer.peerConnection.addTrack(track, viewer.localStream));
+                localView.srcObject = viewer.localStream;
+            } catch (e) {
+                console.error('[VIEWER] Could not find webcam');
+                return;
+            }
         }
 
         // Create an SDP offer to send to the master


### PR DESCRIPTION
Add a guard in master and viewer example to exclude the case when we only have data channel only mode.

Issue https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/issues/46.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
