### PR TITLE
Cleanup resources when users close the tab

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -1,3 +1,5 @@
+let ROLE = null; // Possible values: 'master', 'viewer', null
+
 function configureLogging() {
     function log(level, messages) {
         const text = messages
@@ -70,6 +72,25 @@ function onStatsReport(report) {
     // TODO: Publish stats
 }
 
+function onStop() {
+    if (!ROLE) {
+        return;
+    }
+
+    if (ROLE === 'master') {
+        stopMaster();
+        $('#master').addClass('d-none');
+    } else {
+        stopViewer();
+        $('#viewer').addClass('d-none');
+    }
+    
+    $('#form').removeClass('d-none');
+    ROLE = null;
+}
+
+window.addEventListener('beforeunload', onStop);
+
 window.addEventListener('error', function(event) {
     console.error(event.message);
     event.preventDefault();
@@ -83,6 +104,7 @@ window.addEventListener('unhandledrejection', function(event) {
 configureLogging();
 
 $('#master-button').click(async () => {
+    ROLE = 'master';
     $('#form').addClass('d-none');
     $('#master').removeClass('d-none');
 
@@ -101,14 +123,10 @@ $('#master-button').click(async () => {
     });
 });
 
-$('#stop-master-button').click(async () => {
-    stopMaster();
-
-    $('#form').removeClass('d-none');
-    $('#master').addClass('d-none');
-});
+$('#stop-master-button').click(onStop);
 
 $('#viewer-button').click(async () => {
+    ROLE = 'viewer';
     $('#form').addClass('d-none');
     $('#viewer').removeClass('d-none');
 
@@ -127,12 +145,7 @@ $('#viewer-button').click(async () => {
     });
 });
 
-$('#stop-viewer-button').click(async () => {
-    stopViewer();
-
-    $('#form').removeClass('d-none');
-    $('#viewer').addClass('d-none');
-});
+$('#stop-viewer-button').click(onStop);
 
 $('#create-channel-button').click(async () => {
     const formValues = getFormValues();


### PR DESCRIPTION
This PR will allow the sample to properly clean up the resources by explicitly telling either master/viewer that the user is about to close the browser tab.

Related to https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/475

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
