### PR TITLE
Update codecov

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1453,9 +1453,9 @@
             }
         },
         "@tootallnate/once": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.0.0.tgz",
-            "integrity": "sha512-KYyTT/T6ALPkIRd2Ge080X/BsXvy9O0hcWTtMWkPvwAwF99+vn6Dv4GzrFT/Nn1LePr+FFDbRXXlqmsy9lw2zA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
             "dev": true
         },
         "@trust/keyto": {
@@ -1976,9 +1976,9 @@
             "dev": true
         },
         "agent-base": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
-            "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
+            "integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
             "dev": true,
             "requires": {
                 "debug": "4"
@@ -3103,9 +3103,9 @@
             "dev": true
         },
         "codecov": {
-            "version": "3.6.5",
-            "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.6.5.tgz",
-            "integrity": "sha512-v48WuDMUug6JXwmmfsMzhCHRnhUf8O3duqXvltaYJKrO1OekZWpB/eH6iIoaxMl8Qli0+u3OxptdsBOYiD7VAQ==",
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.7.1.tgz",
+            "integrity": "sha512-JHWxyPTkMLLJn9SmKJnwAnvY09kg2Os2+Ux+GG7LwZ9g8gzDDISpIN5wAsH1UBaafA/yGcd3KofMaorE8qd6Lw==",
             "dev": true,
             "requires": {
                 "argv": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "@types/jest": "^24.0.23",
         "@typescript-eslint/eslint-plugin": "^2.2.0",
         "@typescript-eslint/parser": "^2.2.0",
-        "codecov": "^3.6.1",
+        "codecov": "^3.7.1",
         "eslint": "^6.3.0",
         "eslint-config-prettier": "^6.3.0",
         "eslint-plugin-kvs-webrtc": "file:eslint",


### PR DESCRIPTION
Codecov has a vulnerability issue with 3.6.1 version, https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/network/alert/package-lock.json/codecov/open. Updating this to fix the issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
