### PR TITLE
Bump more dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,10 +36,10 @@
                 "ts-jest": "^29.1.0",
                 "ts-loader": "^6.0.4",
                 "typescript": "^4.9.5",
-                "webpack": "^5.80.0",
-                "webpack-cli": "^5.0.2",
-                "webpack-dev-server": "^4.13.3",
-                "webpack-merge": "^5.8.0"
+                "webpack": "^5.0.0",
+                "webpack-cli": "^4.7.0",
+                "webpack-dev-server": "^4.0.0",
+                "webpack-merge": "^4.2.2"
             }
         },
         "eslint": {
@@ -6711,42 +6711,34 @@
             }
         },
         "node_modules/@webpack-cli/configtest": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.0.1.tgz",
-            "integrity": "sha512-njsdJXJSiS2iNbQVS0eT8A/KPnmyH4pv1APj2K0d1wrZcBLw+yppxOy4CGqa0OxDJkzfL/XELDhD8rocnIwB5A==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
+            "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
             "dev": true,
-            "engines": {
-                "node": ">=14.15.0"
-            },
             "peerDependencies": {
-                "webpack": "5.x.x",
-                "webpack-cli": "5.x.x"
+                "webpack": "4.x.x || 5.x.x",
+                "webpack-cli": "4.x.x"
             }
         },
         "node_modules/@webpack-cli/info": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.1.tgz",
-            "integrity": "sha512-fE1UEWTwsAxRhrJNikE7v4EotYflkEhBL7EbajfkPlf6E37/2QshOy/D48Mw8G5XMFlQtS6YV42vtbG9zBpIQA==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.5.0.tgz",
+            "integrity": "sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==",
             "dev": true,
-            "engines": {
-                "node": ">=14.15.0"
+            "dependencies": {
+                "envinfo": "^7.7.3"
             },
             "peerDependencies": {
-                "webpack": "5.x.x",
-                "webpack-cli": "5.x.x"
+                "webpack-cli": "4.x.x"
             }
         },
         "node_modules/@webpack-cli/serve": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.2.tgz",
-            "integrity": "sha512-S9h3GmOmzUseyeFW3tYNnWS7gNUuwxZ3mmMq0JyW78Vx1SGKPSkt5bT4pB0rUnVfHjP0EL9gW2bOzmtiTfQt0A==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
+            "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
             "dev": true,
-            "engines": {
-                "node": ">=14.15.0"
-            },
             "peerDependencies": {
-                "webpack": "5.x.x",
-                "webpack-cli": "5.x.x"
+                "webpack-cli": "4.x.x"
             },
             "peerDependenciesMeta": {
                 "webpack-dev-server": {
@@ -8616,7 +8608,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
             "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-            "optional": true,
+            "devOptional": true,
             "engines": {
                 "node": ">= 10"
             }
@@ -12261,12 +12253,12 @@
             }
         },
         "node_modules/interpret": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
-            "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
+            "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
             "dev": true,
             "engines": {
-                "node": ">=10.13.0"
+                "node": ">= 0.10"
             }
         },
         "node_modules/invariant": {
@@ -18800,15 +18792,15 @@
             "peer": true
         },
         "node_modules/rechoir": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
-            "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
+            "integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
             "dev": true,
             "dependencies": {
-                "resolve": "^1.20.0"
+                "resolve": "^1.9.0"
             },
             "engines": {
-                "node": ">= 10.13.0"
+                "node": ">= 0.10"
             }
         },
         "node_modules/regenerate": {
@@ -21728,40 +21720,42 @@
             }
         },
         "node_modules/webpack-cli": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.0.2.tgz",
-            "integrity": "sha512-4y3W5Dawri5+8dXm3+diW6Mn1Ya+Dei6eEVAdIduAmYNLzv1koKVAqsfgrrc9P2mhrYHQphx5htnGkcNwtubyQ==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
+            "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
             "dev": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
-                "@webpack-cli/configtest": "^2.0.1",
-                "@webpack-cli/info": "^2.0.1",
-                "@webpack-cli/serve": "^2.0.2",
+                "@webpack-cli/configtest": "^1.2.0",
+                "@webpack-cli/info": "^1.5.0",
+                "@webpack-cli/serve": "^1.7.0",
                 "colorette": "^2.0.14",
-                "commander": "^10.0.1",
+                "commander": "^7.0.0",
                 "cross-spawn": "^7.0.3",
-                "envinfo": "^7.7.3",
                 "fastest-levenshtein": "^1.0.12",
                 "import-local": "^3.0.2",
-                "interpret": "^3.1.1",
-                "rechoir": "^0.8.0",
+                "interpret": "^2.2.0",
+                "rechoir": "^0.7.0",
                 "webpack-merge": "^5.7.3"
             },
             "bin": {
                 "webpack-cli": "bin/cli.js"
             },
             "engines": {
-                "node": ">=14.15.0"
+                "node": ">=10.13.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "webpack": "5.x.x"
+                "webpack": "4.x.x || 5.x.x"
             },
             "peerDependenciesMeta": {
                 "@webpack-cli/generators": {
+                    "optional": true
+                },
+                "@webpack-cli/migrate": {
                     "optional": true
                 },
                 "webpack-bundle-analyzer": {
@@ -21777,15 +21771,6 @@
             "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
             "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
             "dev": true
-        },
-        "node_modules/webpack-cli/node_modules/commander": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-            "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-            "dev": true,
-            "engines": {
-                "node": ">=14"
-            }
         },
         "node_modules/webpack-cli/node_modules/cross-spawn": {
             "version": "7.0.3",
@@ -21829,6 +21814,19 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/webpack-cli/node_modules/webpack-merge": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
+            "integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
+            "dev": true,
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
             }
         },
         "node_modules/webpack-cli/node_modules/which": {
@@ -22201,16 +22199,12 @@
             }
         },
         "node_modules/webpack-merge": {
-            "version": "5.8.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
-            "integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
+            "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
             "dev": true,
             "dependencies": {
-                "clone-deep": "^4.0.1",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
+                "lodash": "^4.17.15"
             }
         },
         "node_modules/webpack-sources": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,10 +36,10 @@
                 "ts-jest": "^29.1.0",
                 "ts-loader": "^6.0.4",
                 "typescript": "^4.9.5",
-                "webpack": "^5.0.0",
-                "webpack-cli": "^4.7.0",
-                "webpack-dev-server": "^4.0.0",
-                "webpack-merge": "^4.2.2"
+                "webpack": "^5.80.0",
+                "webpack-cli": "^5.0.2",
+                "webpack-dev-server": "^4.13.3",
+                "webpack-merge": "^5.8.0"
             }
         },
         "eslint": {
@@ -2452,30 +2452,6 @@
                 "node": ">= 10.0.0"
             }
         },
-        "node_modules/@expo/cli/node_modules/xml2js": {
-            "version": "0.4.23",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-            "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "sax": ">=0.6.0",
-                "xmlbuilder": "~11.0.0"
-            },
-            "engines": {
-                "node": ">=4.0.0"
-            }
-        },
-        "node_modules/@expo/cli/node_modules/xmlbuilder": {
-            "version": "11.0.1",
-            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
         "node_modules/@expo/code-signing-certificates": {
             "version": "0.0.5",
             "resolved": "https://registry.npmjs.org/@expo/code-signing-certificates/-/code-signing-certificates-0.0.5.tgz",
@@ -2636,30 +2612,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/@expo/config-plugins/node_modules/xml2js": {
-            "version": "0.4.23",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-            "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "sax": ">=0.6.0",
-                "xmlbuilder": "~11.0.0"
-            },
-            "engines": {
-                "node": ">=4.0.0"
-            }
-        },
-        "node_modules/@expo/config-plugins/node_modules/xmlbuilder": {
-            "version": "11.0.1",
-            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=4.0"
             }
         },
         "node_modules/@expo/config-types": {
@@ -6759,34 +6711,42 @@
             }
         },
         "node_modules/@webpack-cli/configtest": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
-            "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.0.1.tgz",
+            "integrity": "sha512-njsdJXJSiS2iNbQVS0eT8A/KPnmyH4pv1APj2K0d1wrZcBLw+yppxOy4CGqa0OxDJkzfL/XELDhD8rocnIwB5A==",
             "dev": true,
+            "engines": {
+                "node": ">=14.15.0"
+            },
             "peerDependencies": {
-                "webpack": "4.x.x || 5.x.x",
-                "webpack-cli": "4.x.x"
+                "webpack": "5.x.x",
+                "webpack-cli": "5.x.x"
             }
         },
         "node_modules/@webpack-cli/info": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.5.0.tgz",
-            "integrity": "sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.1.tgz",
+            "integrity": "sha512-fE1UEWTwsAxRhrJNikE7v4EotYflkEhBL7EbajfkPlf6E37/2QshOy/D48Mw8G5XMFlQtS6YV42vtbG9zBpIQA==",
             "dev": true,
-            "dependencies": {
-                "envinfo": "^7.7.3"
+            "engines": {
+                "node": ">=14.15.0"
             },
             "peerDependencies": {
-                "webpack-cli": "4.x.x"
+                "webpack": "5.x.x",
+                "webpack-cli": "5.x.x"
             }
         },
         "node_modules/@webpack-cli/serve": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
-            "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.2.tgz",
+            "integrity": "sha512-S9h3GmOmzUseyeFW3tYNnWS7gNUuwxZ3mmMq0JyW78Vx1SGKPSkt5bT4pB0rUnVfHjP0EL9gW2bOzmtiTfQt0A==",
             "dev": true,
+            "engines": {
+                "node": ">=14.15.0"
+            },
             "peerDependencies": {
-                "webpack-cli": "4.x.x"
+                "webpack": "5.x.x",
+                "webpack-cli": "5.x.x"
             },
             "peerDependenciesMeta": {
                 "webpack-dev-server": {
@@ -8656,7 +8616,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
             "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-            "devOptional": true,
+            "optional": true,
             "engines": {
                 "node": ">= 10"
             }
@@ -9382,9 +9342,9 @@
             "devOptional": true
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.369",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.369.tgz",
-            "integrity": "sha512-LfxbHXdA/S+qyoTEA4EbhxGjrxx7WK2h6yb5K2v0UCOufUKX+VZaHbl3svlzZfv9sGseym/g3Ne4DpsgRULmqg==",
+            "version": "1.4.370",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.370.tgz",
+            "integrity": "sha512-c+wzD4sCYQeNeasbnArwsU3ig6+lR6bwQmxfMjB6bx+XoopVSPFp+7ZLxqa90MTC+Tq9QQ5l7zsMNG9GgMBorg==",
             "devOptional": true
         },
         "node_modules/elliptic": {
@@ -10075,9 +10035,9 @@
             }
         },
         "node_modules/expo": {
-            "version": "48.0.11",
-            "resolved": "https://registry.npmjs.org/expo/-/expo-48.0.11.tgz",
-            "integrity": "sha512-KX1RCHhdhdT4DjCeRqYJpZXhdCTuqxHHdNIRoFkmCgkUARYlZbB+Y1U8/KMz8fBAlFoEq99cF/KyRr87VAxRCw==",
+            "version": "48.0.12",
+            "resolved": "https://registry.npmjs.org/expo/-/expo-48.0.12.tgz",
+            "integrity": "sha512-DjHYxIHOEvsM+yd2JFnRXtogTZKYWVhyT76Q8CKz91cdM7coXPtTAC23dj9nHx6aKP8RmHnpr902lY5uYPP83A==",
             "optional": true,
             "peer": true,
             "dependencies": {
@@ -11047,16 +11007,6 @@
             },
             "engines": {
                 "node": ">=4.0.0"
-            }
-        },
-        "node_modules/find-babel-config/node_modules/json5": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-            "integrity": "sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==",
-            "optional": true,
-            "peer": true,
-            "bin": {
-                "json5": "lib/cli.js"
             }
         },
         "node_modules/find-cache-dir": {
@@ -12311,12 +12261,12 @@
             }
         },
         "node_modules/interpret": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
-            "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+            "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
             "dev": true,
             "engines": {
-                "node": ">= 0.10"
+                "node": ">=10.13.0"
             }
         },
         "node_modules/invariant": {
@@ -15446,18 +15396,6 @@
             },
             "engines": {
                 "node": ">=4.0.0"
-            }
-        },
-        "node_modules/loader-utils/node_modules/json5": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-            "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-            "dev": true,
-            "dependencies": {
-                "minimist": "^1.2.0"
-            },
-            "bin": {
-                "json5": "lib/cli.js"
             }
         },
         "node_modules/locate-path": {
@@ -18862,15 +18800,15 @@
             "peer": true
         },
         "node_modules/rechoir": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
-            "integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+            "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
             "dev": true,
             "dependencies": {
-                "resolve": "^1.9.0"
+                "resolve": "^1.20.0"
             },
             "engines": {
-                "node": ">= 0.10"
+                "node": ">= 10.13.0"
             }
         },
         "node_modules/regenerate": {
@@ -21790,42 +21728,40 @@
             }
         },
         "node_modules/webpack-cli": {
-            "version": "4.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
-            "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.0.2.tgz",
+            "integrity": "sha512-4y3W5Dawri5+8dXm3+diW6Mn1Ya+Dei6eEVAdIduAmYNLzv1koKVAqsfgrrc9P2mhrYHQphx5htnGkcNwtubyQ==",
             "dev": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
-                "@webpack-cli/configtest": "^1.2.0",
-                "@webpack-cli/info": "^1.5.0",
-                "@webpack-cli/serve": "^1.7.0",
+                "@webpack-cli/configtest": "^2.0.1",
+                "@webpack-cli/info": "^2.0.1",
+                "@webpack-cli/serve": "^2.0.2",
                 "colorette": "^2.0.14",
-                "commander": "^7.0.0",
+                "commander": "^10.0.1",
                 "cross-spawn": "^7.0.3",
+                "envinfo": "^7.7.3",
                 "fastest-levenshtein": "^1.0.12",
                 "import-local": "^3.0.2",
-                "interpret": "^2.2.0",
-                "rechoir": "^0.7.0",
+                "interpret": "^3.1.1",
+                "rechoir": "^0.8.0",
                 "webpack-merge": "^5.7.3"
             },
             "bin": {
                 "webpack-cli": "bin/cli.js"
             },
             "engines": {
-                "node": ">=10.13.0"
+                "node": ">=14.15.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "webpack": "4.x.x || 5.x.x"
+                "webpack": "5.x.x"
             },
             "peerDependenciesMeta": {
                 "@webpack-cli/generators": {
-                    "optional": true
-                },
-                "@webpack-cli/migrate": {
                     "optional": true
                 },
                 "webpack-bundle-analyzer": {
@@ -21841,6 +21777,15 @@
             "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
             "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
             "dev": true
+        },
+        "node_modules/webpack-cli/node_modules/commander": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+            "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+            "dev": true,
+            "engines": {
+                "node": ">=14"
+            }
         },
         "node_modules/webpack-cli/node_modules/cross-spawn": {
             "version": "7.0.3",
@@ -21884,19 +21829,6 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/webpack-cli/node_modules/webpack-merge": {
-            "version": "5.8.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
-            "integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
-            "dev": true,
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "wildcard": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
             }
         },
         "node_modules/webpack-cli/node_modules/which": {
@@ -22269,12 +22201,16 @@
             }
         },
         "node_modules/webpack-merge": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
-            "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
+            "integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
             "dev": true,
             "dependencies": {
-                "lodash": "^4.17.15"
+                "clone-deep": "^4.0.1",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
             }
         },
         "node_modules/webpack-sources": {
@@ -22421,9 +22357,9 @@
             "peer": true
         },
         "node_modules/wildcard": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
-            "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
+            "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
             "dev": true
         },
         "node_modules/wonka": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "amazon-kinesis-video-streams-webrtc",
-    "version": "2.0.3",
+    "version": "2.0.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "amazon-kinesis-video-streams-webrtc",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "license": "Apache-2.0",
             "dependencies": {
                 "isomorphic-webcrypto": "^2.3.6",

--- a/package.json
+++ b/package.json
@@ -49,10 +49,10 @@
         "ts-jest": "^29.1.0",
         "ts-loader": "^6.0.4",
         "typescript": "^4.9.5",
-        "webpack": "^5.80.0",
-        "webpack-cli": "^5.0.2",
-        "webpack-dev-server": "^4.13.3",
-        "webpack-merge": "^5.8.0"
+        "webpack": "^5.0.0",
+        "webpack-cli": "^4.7.0",
+        "webpack-dev-server": "^4.0.0",
+        "webpack-merge": "^4.2.2"
     },
     "dependencies": {
         "isomorphic-webcrypto": "^2.3.6",

--- a/package.json
+++ b/package.json
@@ -49,10 +49,10 @@
         "ts-jest": "^29.1.0",
         "ts-loader": "^6.0.4",
         "typescript": "^4.9.5",
-        "webpack": "^5.0.0",
-        "webpack-cli": "^4.7.0",
-        "webpack-dev-server": "^4.0.0",
-        "webpack-merge": "^4.2.2"
+        "webpack": "^5.80.0",
+        "webpack-cli": "^5.0.2",
+        "webpack-dev-server": "^4.13.3",
+        "webpack-merge": "^5.8.0"
     },
     "dependencies": {
         "isomorphic-webcrypto": "^2.3.6",
@@ -65,6 +65,8 @@
     },
     "overrides": {
         "qs": "6.7.3",
+        "xml2js": "^0.5.0",
+        "json5": "^2.2.3",
         "@types/babel__traverse": "7.18.2",
         "@types/express-serve-static-core": "4.17.29"
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "amazon-kinesis-video-streams-webrtc",
-    "version": "2.0.3",
+    "version": "2.0.4",
     "description": "Amazon Kinesis Video Streams WebRTC SDK for JavaScript.",
     "repository": {
         "type": "git",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Override dependencies version.

```
json5  <1.0.2
Severity: high
Prototype Pollution in JSON5 via Parse Method - https://github.com/advisories/GHSA-9c47-m6qq-7p4h
fix available via `npm audit fix`
node_modules/find-babel-config/node_modules/json5
  find-babel-config  <=1.2.0
  Depends on vulnerable versions of json5
  node_modules/find-babel-config
    babel-plugin-module-resolver  2.3.0 - 4.1.0
    Depends on vulnerable versions of find-babel-config
    node_modules/babel-plugin-module-resolver
      babel-preset-expo  *
      Depends on vulnerable versions of babel-plugin-module-resolver
      node_modules/babel-preset-expo
        expo  >=14.0.0
        Depends on vulnerable versions of @expo/cli
        Depends on vulnerable versions of @expo/config
        Depends on vulnerable versions of @expo/config-plugins
        Depends on vulnerable versions of babel-preset-expo
        Depends on vulnerable versions of expo-asset
        Depends on vulnerable versions of expo-constants
        node_modules/expo

xml2js  <0.5.0
Severity: high
xml2js is vulnerable to prototype pollution  - https://github.com/advisories/GHSA-776f-qx25-q3cc
fix available via `npm audit fix`
node_modules/@expo/cli/node_modules/xml2js
node_modules/@expo/config-plugins/node_modules/xml2js
  @expo/config-plugins  *
  Depends on vulnerable versions of xml2js
  node_modules/@expo/config-plugins
    @expo/cli  >=0.1.0
    Depends on vulnerable versions of @expo/config
    Depends on vulnerable versions of @expo/config-plugins
    Depends on vulnerable versions of @expo/dev-server
    Depends on vulnerable versions of @expo/metro-config
    Depends on vulnerable versions of @expo/prebuild-config
    node_modules/@expo/cli
    @expo/config  >=3.3.23-alpha.0
    Depends on vulnerable versions of @expo/config-plugins
    node_modules/@expo/config
      @expo/metro-config  >=0.1.49-alpha.0
      Depends on vulnerable versions of @expo/config
      node_modules/@expo/metro-config
        @expo/dev-server  >=0.1.49-alpha.0
        Depends on vulnerable versions of @expo/metro-config
        node_modules/@expo/dev-server
      expo-constants  >=10.1.2
      Depends on vulnerable versions of @expo/config
      node_modules/expo-constants
        expo-asset  >=8.6.1
        Depends on vulnerable versions of expo-constants
        node_modules/expo-asset
    @expo/prebuild-config  *
    Depends on vulnerable versions of @expo/config
    Depends on vulnerable versions of @expo/config-plugins
    Depends on vulnerable versions of xml2js
    node_modules/@expo/cli/node_modules/@expo/prebuild-config
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
