### PR TITLE
Add logs for no sender client id

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -18,6 +18,8 @@ function configureLogging() {
                     return `${JSON.stringify(rest, null, 2)}\n${stack}`;
                 } else if (typeof message === 'object') {
                     return JSON.stringify(message, null, 2);
+                } else if (message === undefined) {
+                    return 'undefined';
                 } else {
                     return message;
                 }

--- a/examples/master.js
+++ b/examples/master.js
@@ -344,5 +344,5 @@ function sendMasterMessage(message) {
 }
 
 function printSignalingLog(message, clientId) {
-    console.log(`${message}${clientId ? ': ' + clientId : ''}`);
+    console.log(`${message}${clientId ? ': ' + clientId : ' (no senderClientId provided)'}`);
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Adjust log statement if [senderClientId](https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/kvswebrtc-websocket-apis-7.html) is not present

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
