### PR TITLE
Debug-level logs, multi-viewer interface, and more tooltips

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ This class is the main class for interfacing with the KVS signaling service. It 
     * `secretAccessKey` {string} AWS secret access key.
     * `sessionToken` {string} Optional. AWS session token.
   * `requestSigner` {RequestSigner} Optional. A custom method for overriding the default SigV4 request signing.
-  * `systemClockOffset` {number} Optional. Applies the given offset when setting the date in the SigV4 signature. 
+  * `systemClockOffset` {number} Optional. Applies the given offset when setting the date in the SigV4 signature.
   See [systemClockOffset](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#systemClockOffset-property) and [correctClockSkew](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#correctClockSkew-property)
   properties of the AWS SDK.
 
@@ -399,7 +399,7 @@ See [KVS WebRTC Access Control Documentation](https://docs.aws.amazon.com/kinesi
 #### Running WebRTC Test Page Locally
 The SDK and test page can be edited and run locally by following these instructions:
 
-NodeJS version 8+ is required.
+See the supported node versions in [ci.yml](.github/workflows/ci.yml).
 
 1. Run `npm install` to download dependencies.
 1. Run `npm run develop` to run the webserver.
@@ -408,6 +408,8 @@ NodeJS version 8+ is required.
 You will need to provide an AWS region, AWS credentials, and a Channel Name.
 
 The source code for the test page is in the [`examples`](examples) directory.
+
+For advanced debugging, use the `WebRTC Internals` tool your browser provides.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ See [KVS WebRTC Access Control Documentation](https://docs.aws.amazon.com/kinesi
 #### Running WebRTC Test Page Locally
 The SDK and test page can be edited and run locally by following these instructions:
 
-See the supported node versions in [ci.yml](.github/workflows/ci.yml).
+NodeJS version 16+ is required.
 
 1. Run `npm install` to download dependencies.
 1. Run `npm run develop` to run the webserver.

--- a/examples/app.js
+++ b/examples/app.js
@@ -7,7 +7,7 @@ function configureLogging() {
         const text = messages
             .map(message => {
                 if (message instanceof Error) {
-                    const { stack, ...rest } = message;
+                    const {stack, ...rest} = message;
                     if (Object.keys(rest).length === 0) {
                         if (stack) {
                             return stack;
@@ -36,25 +36,25 @@ function configureLogging() {
     }
 
     console._error = console.error;
-    console.error = function(...rest) {
+    console.error = function (...rest) {
         log('ERROR', Array.prototype.slice.call(rest));
         console._error.apply(this, rest);
     };
 
     console._warn = console.warn;
-    console.warn = function(...rest) {
+    console.warn = function (...rest) {
         log('WARN', Array.prototype.slice.call(rest));
         console._warn.apply(this, rest);
     };
 
     console._log = console.log;
-    console.log = function(...rest) {
+    console.log = function (...rest) {
         log('INFO', Array.prototype.slice.call(rest));
         console._log.apply(this, rest);
     };
 
     console._debug = console.debug;
-    console.debug = function(...rest) {
+    console.debug = function (...rest) {
         log('DEBUG', Array.prototype.slice.call(rest));
         console._debug.apply(this, rest);
     };
@@ -127,12 +127,12 @@ function onStop() {
 
 window.addEventListener('beforeunload', onStop);
 
-window.addEventListener('error', function(event) {
+window.addEventListener('error', function (event) {
     console.error(event.message);
     event.preventDefault();
 });
 
-window.addEventListener('unhandledrejection', function(event) {
+window.addEventListener('unhandledrejection', function (event) {
     console.error(event.reason.toString());
     event.preventDefault();
 });
@@ -323,6 +323,10 @@ $('#region').on('focusout', event => {
 function addViewerTrackToMaster(viewerId, track) {
     $('#empty-video-placeholder')?.remove();
 
+    $('#viewer-view-holder')
+        .find('#' + viewerId)
+        ?.remove();
+
     const container = $(`<div id="${viewerId}"></div>`);
     const video = $(`<video autoPlay playsInline controls title="${viewerId}"></video>`);
     video.addClass('remote-view');
@@ -421,26 +425,26 @@ $('#ingestMedia').click(() => {
 // Read/Write all of the fields to/from localStorage so that fields are not lost on refresh.
 const urlParams = new URLSearchParams(window.location.search);
 const fields = [
-    { field: 'channelName', type: 'text' },
-    { field: 'clientId', type: 'text' },
-    { field: 'region', type: 'text' },
-    { field: 'accessKeyId', type: 'text' },
-    { field: 'secretAccessKey', type: 'text' },
-    { field: 'sessionToken', type: 'text' },
-    { field: 'endpoint', type: 'text' },
-    { field: 'sendVideo', type: 'checkbox' },
-    { field: 'sendAudio', type: 'checkbox' },
-    { field: 'widescreen', type: 'radio', name: 'resolution' },
-    { field: 'fullscreen', type: 'radio', name: 'resolution' },
-    { field: 'openDataChannel', type: 'checkbox' },
-    { field: 'useTrickleICE', type: 'checkbox' },
-    { field: 'natTraversalEnabled', type: 'radio', name: 'natTraversal' },
-    { field: 'forceSTUN', type: 'radio', name: 'natTraversal' },
-    { field: 'forceTURN', type: 'radio', name: 'natTraversal' },
-    { field: 'natTraversalDisabled', type: 'radio', name: 'natTraversal' },
-    { field: 'ingestMedia', type: 'checkbox' },
+    {field: 'channelName', type: 'text'},
+    {field: 'clientId', type: 'text'},
+    {field: 'region', type: 'text'},
+    {field: 'accessKeyId', type: 'text'},
+    {field: 'secretAccessKey', type: 'text'},
+    {field: 'sessionToken', type: 'text'},
+    {field: 'endpoint', type: 'text'},
+    {field: 'sendVideo', type: 'checkbox'},
+    {field: 'sendAudio', type: 'checkbox'},
+    {field: 'widescreen', type: 'radio', name: 'resolution'},
+    {field: 'fullscreen', type: 'radio', name: 'resolution'},
+    {field: 'openDataChannel', type: 'checkbox'},
+    {field: 'useTrickleICE', type: 'checkbox'},
+    {field: 'natTraversalEnabled', type: 'radio', name: 'natTraversal'},
+    {field: 'forceSTUN', type: 'radio', name: 'natTraversal'},
+    {field: 'forceTURN', type: 'radio', name: 'natTraversal'},
+    {field: 'natTraversalDisabled', type: 'radio', name: 'natTraversal'},
+    {field: 'ingestMedia', type: 'checkbox'},
 ];
-fields.forEach(({ field, type, name }) => {
+fields.forEach(({field, type, name}) => {
     const id = '#' + field;
 
     // Read field from localStorage
@@ -469,7 +473,7 @@ fields.forEach(({ field, type, name }) => {
     }
 
     // Write field to localstorage on change event
-    $(id).change(function() {
+    $(id).change(function () {
         try {
             if (type === 'checkbox') {
                 localStorage.setItem(field, $(id).is(':checked'));
@@ -489,7 +493,7 @@ fields.forEach(({ field, type, name }) => {
 });
 
 // Enable tooltips
-$(document).ready(function() {
+$(document).ready(function () {
     $('[data-toggle="tooltip"]').tooltip();
 });
 

--- a/examples/app.js
+++ b/examples/app.js
@@ -1,5 +1,5 @@
 let ROLE = null; // Possible values: 'master', 'viewer', null
-const LOG_LEVELS = ['info', 'warn', 'error'];
+const LOG_LEVELS = ['debug', 'info', 'warn', 'error'];
 let LOG_LEVEL = 'info'; // Possible values: any value of LOG_LEVELS
 
 function configureLogging() {
@@ -50,6 +50,12 @@ function configureLogging() {
         log('INFO', Array.prototype.slice.call(rest));
         console._log.apply(this, rest);
     };
+
+    console._debug = console.debug;
+    console.debug = function(...rest) {
+        log('DEBUG', Array.prototype.slice.call(rest));
+        console._debug.apply(this, rest);
+    };
 }
 
 function getRandomClientId() {
@@ -89,7 +95,7 @@ function toggleDataChannelElements() {
 }
 
 function onStatsReport(report) {
-    // TODO: Publish stats
+    console.debug('[STATS]', [...report.entries()]);
 }
 
 function onStop() {

--- a/examples/app.js
+++ b/examples/app.js
@@ -419,15 +419,8 @@ fields.forEach(({ field, type, name }) => {
 });
 
 // Enable tooltips
-$(document).ready(function () {
+$(document).ready(function() {
     $('[data-toggle="tooltip"]').tooltip();
-
-    // $('[data-toggle="tooltip"]').on('show.bs.tooltip', function (key) {
-    //     // Only one tooltip should ever be open at a time
-    //     $('.tooltip')
-    //         .not(this)
-    //         .fadeOut();
-    // });
 });
 
 // The page is all setup. Hide the loading spinner and show the page content.

--- a/examples/app.js
+++ b/examples/app.js
@@ -95,7 +95,7 @@ function toggleDataChannelElements() {
 }
 
 function onStatsReport(report) {
-    console.debug('[STATS]', [...report.entries()]);
+    console._debug('[STATS]', Object.fromEntries([...report.entries()]));
 }
 
 function onStop() {

--- a/examples/app.js
+++ b/examples/app.js
@@ -421,6 +421,13 @@ fields.forEach(({ field, type, name }) => {
 // Enable tooltips
 $(document).ready(function () {
     $('[data-toggle="tooltip"]').tooltip();
+
+    // $('[data-toggle="tooltip"]').on('show.bs.tooltip', function (key) {
+    //     // Only one tooltip should ever be open at a time
+    //     $('.tooltip')
+    //         .not(this)
+    //         .fadeOut();
+    // });
 });
 
 // The page is all setup. Hide the loading spinner and show the page content.

--- a/examples/app.js
+++ b/examples/app.js
@@ -95,6 +95,7 @@ function toggleDataChannelElements() {
 }
 
 function onStatsReport(report) {
+    // Only print these to the console, as this prints a LOT of stuff.
     console._debug('[STATS]', Object.fromEntries([...report.entries()]));
 }
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -107,7 +107,7 @@
             <h4>NAT Traversal</h4>
             <p><small>Control settings for ICE candidate generation.</small>
             <span data-delay="{ &quot;hide&quot;: 1500 }" data-position="auto" tabindex="0" class="text-info" data-toggle="tooltip" data-html="true" title="
-                    <p>Determines the types of <code>ICE candidates</code> that are generated.<br/><br/>STUN/TURN = host, server reflexive, and relay<br/>TURN only = relay<br/>Disabled = host</p>
+                    <p>Determines the types of <code>ICE candidates</code> that are generated.<br/><br/>STUN/TURN = host, server reflexive, and relay<br/>STUN only = server reflexive<br/>TURN only = relay<br/>Disabled = host</p>
                     <a href=&quot;https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/kvswebrtc-how-it-works.html#how-kvswebrtc-works&quot;>Additional information</a>
                 "><sup>&#9432;</sup></span></p>
             <div class="form-group">
@@ -163,9 +163,9 @@
                     <h5>Master Section</h5>
                     <div class="video-container"><video class="local-view" autoplay playsinline controls muted></video></div>
                 </div>
-                <div class="col">
+                <div id="viewer-view-holder" class="col">
                     <h5>Viewer Return Channel</h5>
-                    <div class="video-container"><video class="remote-view" autoplay playsinline controls></video></div>
+                    <div id="empty-video-placeholder" class="video-container"><video class="remote-view" autoplay playsinline controls></video></div>
                 </div>
             </div>
             <div class="row datachannel">

--- a/examples/index.html
+++ b/examples/index.html
@@ -21,7 +21,7 @@
     <p>This is the KVS Signaling Channel WebRTC test page. Use this page to connect to a signaling channel as either the MASTER or as a VIEWER.</p>
 
     <div class="row loader"></div>
-    <div id="main" class="d-none">
+    <flex id="main" class="d-none">
         <form id="form" onsubmit="return false">
             <h4>KVS Endpoint</h4>
             <div class="form-group has-validation" style="position: relative;">
@@ -104,7 +104,11 @@
                 </div>
             </div>
             <h4>NAT Traversal</h4>
-            <p><small>Control settings for ICE candidate generation.</small></p>
+            <p><small>Control settings for ICE candidate generation.</small>
+            <span data-delay="{ &quot;hide&quot;: 1500 }" data-position="auto" tabindex="0" class="text-info" data-toggle="tooltip" data-html="true" title="
+                    <p>Determines the types of <code>ICE candidates</code> that are generated.<br/><br/>STUN/TURN = host, server reflexive, and relay<br/>TURN only = relay<br/>Disabled = host</p>
+                    <a href=&quot;https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/kvswebrtc-how-it-works.html#how-kvswebrtc-works&quot;>Additional information</a>
+                "><sup>&#9432;</sup></span></p>
             <div class="form-group">
                 <div class="form-check form-check">
                     <input class="form-check-input" type="radio" name="natTraversal" id="natTraversalEnabled" value="option2" checked>

--- a/examples/index.html
+++ b/examples/index.html
@@ -59,6 +59,10 @@
             </div>
             <div class="form-group">
                 <label for="clientId">Client Id <small>(optional)</small></label>
+                <span data-delay="{ &quot;hide&quot;: 1500 }" data-position="auto" tabindex="0" class="text-info" data-toggle="tooltip" data-html="true" title="
+                    <p>Only used in <code>viewer</code> mode. A unique identifier for the client. If left empty, a random client id will be generated.</p>
+                    <a href=&quot;https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/kvswebrtc-websocket-apis-1.html&quot;>Additional information</a>
+                    "><sup>&#9432;</sup></span>
                 <input type="text" class="form-control" id="clientId" placeholder="Client id">
             </div>
             <h4>Tracks</h4>

--- a/examples/index.html
+++ b/examples/index.html
@@ -203,6 +203,7 @@
         <div class="card bg-light mb-3">
             <div style="display: flex; justify-content: space-between;">
                 <div id="tabs">
+                    <button id="debug-button" class="btn btn-light" onClick="logLevelSelected(event)" data-level="DEBUG">DEBUG</button>
                     <button id="info-button" class="btn btn-primary" onClick="logLevelSelected(event)" data-level="INFO">INFO</button>
                     <button id="warn-button" class="btn btn-light" onClick="logLevelSelected(event)" data-level="WARN">WARN</button>
                     <button id="error-button" class="btn btn-light" onClick="logLevelSelected(event)" data-level="ERROR">ERROR</button>

--- a/examples/master.js
+++ b/examples/master.js
@@ -205,38 +205,7 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
             }
 
             peerConnection.addEventListener('connectionstatechange', async event => {
-                console.debug('[MASTER] PeerConnection state:', peerConnection.connectionState);
-                if (peerConnection.connectionState === 'connected') {
-                    console.log('[MASTER] Connection to viewer successful!');
-                    const stats = await peerConnection.getStats();
-                    if (!stats) return;
-
-                    let selectedPairId = null;
-                    for (const [, stat] of stats) {
-                        if (stat.type === 'transport') {
-                            selectedPairId = stat.selectedCandidatePairId;
-                            break;
-                        }
-                    }
-
-                    let candidatePair = stats.get(selectedPairId);
-                    if (!candidatePair) {
-                        for (const [, stat] of stats) {
-                            if (stat.type === 'candidate-pair' && stat.selected) {
-                                candidatePair = stat;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (candidatePair) {
-                        console.debug('[MASTER] Chosen pair:', candidatePair);
-                        console.debug('remote candidate:', stats.get(candidatePair.remoteCandidateId));
-                        console.debug('local candidate:', stats.get(candidatePair.localCandidateId));
-                    }
-                } else if (peerConnection.connectionState === 'failed') {
-                    console.error('[MASTER] Connection to viewer failed!');
-                }
+                printPeerConnectionStateInfo(event, '[MASTER]');
             });
 
             // Send any ICE candidates to the other peer

--- a/examples/master.js
+++ b/examples/master.js
@@ -237,12 +237,7 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
             // As remote tracks are received, add them to the remote view
             peerConnection.addEventListener('track', event => {
                 printSignalingLog('[MASTER] Received remote track from client', remoteClientId);
-                if (!remoteView.srcObject) {
-                    console.log('asdfasdfsadfsafdsfasfdasfasfsadfasdfasdfsafdsfasdfadsfasdfsdafdsafadsf');
-                    addViewerTrackToMaster(remoteClientId, event.streams[0]);
-                    return;
-                }
-                remoteView.srcObject = event.streams[0];
+                addViewerTrackToMaster(remoteClientId, event.streams[0]);
             });
 
             // If there's no video/audio, master.localStream will be null. So, we should skip adding the tracks from it.

--- a/examples/master.js
+++ b/examples/master.js
@@ -208,7 +208,7 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
             }
 
             peerConnection.addEventListener('connectionstatechange', async event => {
-                printPeerConnectionStateInfo(event, '[MASTER]');
+                printPeerConnectionStateInfo(event, '[MASTER]', remoteClientId);
             });
 
             // Send any ICE candidates to the other peer
@@ -237,7 +237,9 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
             // As remote tracks are received, add them to the remote view
             peerConnection.addEventListener('track', event => {
                 printSignalingLog('[MASTER] Received remote track from client', remoteClientId);
-                if (remoteView.srcObject) {
+                if (!remoteView.srcObject) {
+                    console.log('asdfasdfsadfsafdsfasfdasfasfsadfasdfasdfsafdsfasdfadsfasdfsdafdsafadsf');
+                    addViewerTrackToMaster(remoteClientId, event.streams[0]);
                     return;
                 }
                 remoteView.srcObject = event.streams[0];

--- a/examples/master.js
+++ b/examples/master.js
@@ -185,6 +185,7 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
 
         master.signalingClient.on('sdpOffer', async (offer, remoteClientId) => {
             printSignalingLog('[MASTER] Received SDP offer from client', remoteClientId);
+            console.debug('SDP offer:', offer);
 
             // Create a new peer connection using the offer from the given client
             const peerConnection = new RTCPeerConnection(configuration);
@@ -199,13 +200,14 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
 
             // Poll for connection stats
             if (!master.peerConnectionStatsInterval) {
-                master.peerConnectionStatsInterval = setInterval(() => peerConnection.getStats().then(onStatsReport), 1000);
+                master.peerConnectionStatsInterval = setInterval(() => peerConnection.getStats().then(onStatsReport), 10000);
             }
 
             // Send any ICE candidates to the other peer
             peerConnection.addEventListener('icecandidate', ({ candidate }) => {
                 if (candidate) {
                     printSignalingLog('[MASTER] Generated ICE candidate for client', remoteClientId);
+                    console.debug('ICE candidate:', candidate);
 
                     // When trickle ICE is enabled, send the ICE candidates as they are generated.
                     if (formValues.useTrickleICE) {
@@ -218,6 +220,7 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
                     // When trickle ICE is disabled, send the answer now that all the ICE candidates have ben generated.
                     if (!formValues.useTrickleICE) {
                         printSignalingLog('[MASTER] Sending SDP answer to client', remoteClientId);
+                        console.debug('SDP answer:', peerConnection.localDescription);
                         master.signalingClient.sendSdpAnswer(peerConnection.localDescription, remoteClientId);
                     }
                 }
@@ -250,6 +253,7 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
             // When trickle ICE is enabled, send the answer now and then send ICE candidates as they are generated. Otherwise wait on the ICE candidates.
             if (formValues.useTrickleICE) {
                 printSignalingLog('[MASTER] Sending SDP answer to client', remoteClientId);
+                console.debug('SDP answer:', peerConnection.localDescription);
                 master.signalingClient.sendSdpAnswer(peerConnection.localDescription, remoteClientId);
             }
             printSignalingLog('[MASTER] Generating ICE candidates for client', remoteClientId);

--- a/examples/master.js
+++ b/examples/master.js
@@ -257,6 +257,7 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
 
         master.signalingClient.on('iceCandidate', async (candidate, remoteClientId) => {
             printSignalingLog('[MASTER] Received ICE candidate from client', remoteClientId);
+            console.debug('[MASTER] ICE candidate:', candidate);
 
             // Add the ICE candidate received from the client to the peer connection
             const peerConnection = master.peerConnectionByClientId[remoteClientId];

--- a/examples/master.js
+++ b/examples/master.js
@@ -298,6 +298,7 @@ function stopMaster() {
 
         Object.keys(master.peerConnectionByClientId).forEach(clientId => {
             master.peerConnectionByClientId[clientId].close();
+            removeViewerTrackFromMaster(clientId);
         });
         master.peerConnectionByClientId = [];
 

--- a/examples/master.js
+++ b/examples/master.js
@@ -171,7 +171,8 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
             if (formValues.ingestMedia && master.streamARN) {
                 try {
                     console.log('[MASTER] Joining storage session...');
-                    await master.storageClient.joinStorageSession({
+                    await master.storageClient
+                        .joinStorageSession({
                             channelArn: master.channelARN,
                         })
                         .promise();
@@ -202,6 +203,40 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
             if (!master.peerConnectionStatsInterval) {
                 master.peerConnectionStatsInterval = setInterval(() => peerConnection.getStats().then(onStatsReport), 10000);
             }
+
+            peerConnection.addEventListener('connectionstatechange', async event => {
+                if (peerConnection.connectionState === 'connected') {
+                    console.log('[MASTER] Connection to viewer successful!');
+                    const stats = await peerConnection.getStats();
+                    if (!stats) return;
+
+                    let selectedPairId = null;
+                    for (const [, stat] of stats) {
+                        if (stat.type === 'transport') {
+                            selectedPairId = stat.selectedCandidatePairId;
+                            break;
+                        }
+                    }
+
+                    let candidatePair = stats.get(selectedPairId);
+                    if (!candidatePair) {
+                        for (const [, stat] of stats) {
+                            if (stat.type === 'candidate-pair' && stat.selected) {
+                                candidatePair = stat;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (candidatePair) {
+                        console.debug('[MASTER] Chosen pair:', candidatePair);
+                        console.debug('remote candidate:', stats.get(candidatePair.remoteCandidateId));
+                        console.debug('local candidate:', stats.get(candidatePair.localCandidateId));
+                    }
+                } else if (peerConnection.connectionState === 'failed') {
+                    console.error('[MASTER] Connection to viewer failed!');
+                }
+            });
 
             // Send any ICE candidates to the other peer
             peerConnection.addEventListener('icecandidate', ({ candidate }) => {

--- a/examples/master.js
+++ b/examples/master.js
@@ -205,6 +205,7 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
             }
 
             peerConnection.addEventListener('connectionstatechange', async event => {
+                console.debug('[MASTER] PeerConnection state:', peerConnection.connectionState);
                 if (peerConnection.connectionState === 'connected') {
                     console.log('[MASTER] Connection to viewer successful!');
                     const stats = await peerConnection.getStats();

--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -215,7 +215,7 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, onR
         // Poll for connection stats if metrics enabled
         if (formValues.enableDQPmetrics) {
             // viewer.peerConnectionStatsInterval = setInterval(() => viewer.peerConnection.getStats().then(onStatsReport), 1000);
-            viewer.peerConnectionStatsInterval = setInterval(() => viewer.peerConnection.getStats().then(stats => calcStats(stats)), 1000);
+            viewer.peerConnectionStatsInterval = setInterval(() => viewer.peerConnection.getStats().then(stats => calcStats(stats, formValues.clientId)), 1000);
         }
 
         viewer.signalingClient.on('open', async () => {
@@ -398,7 +398,7 @@ function calcDiffTimestamp2Sec(large, small) {
     return ((large - small) / 1000).toFixed(2);
 }
 
-function calcStats(stats) {
+function calcStats(stats, clientId) {
     let rttCurrent = 0;
 
     let videoBitrate = 0;
@@ -544,7 +544,7 @@ function calcStats(stats) {
                 // prettier-ignore
                 htmlString =
                     '<table><tr><strong>DQP TEST (2min) - <FONT COLOR=RED>RESULTS READY IN: ' + (DQPtestLength - statRunTime) + ' sec</FONT></strong></tr>' +
-                    '<tr><td>Client ID: </td><td>' + getFormValues().clientId + '</td></tr>' +
+                    '<tr><td>Client ID: </td><td>' + clientId + '</td></tr>' +
                     '<tr><td>Time to P2P connection: </td><td>' + connectionTime + ' sec</td></tr>' +
                     '<tr><td>Time to decoded stream(sec): </td><td>' + calcDiffTimestamp2Sec(statStartTime, viewerButtonPressed.getTime()) + ' sec</td></tr></table>';
                 testAvgRTT = avgRtt;
@@ -567,7 +567,7 @@ function calcStats(stats) {
                 htmlString =
                     '<table><tr><th>DQP TEST COMPLETE - RESULTS:</th></tr>' +
                     '<tr><td>Test Run Time:</td><td>' + DQPtestLength + ' sec</td></tr>' +
-                    '<tr><td>Client ID: </td><td>' + getFormValues().clientId + '</td></tr>' +
+                    '<tr><td>Client ID: </td><td>' + clientId + '</td></tr>' +
                     '<tr><td>Time to P2P connection: </td><td>' + connectionTime + ' sec</td></tr>' +
                     '<tr><td>Time to decoded frames: </td><td>' + calcDiffTimestamp2Sec(statStartTime, viewerButtonPressed.getTime()) + ' sec</td></tr>' +
                     '<tr><td>Peer Connection: </td><td>' + connectionString + '</td></tr>' +

--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -196,6 +196,8 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, onR
         });
 
         viewer.peerConnection.addEventListener('connectionstatechange', async event => {
+            console.debug('[VIEWER] PeerConnection state:', viewer.peerConnection.connectionState);
+
             if (viewer.peerConnection.connectionState === 'connected') {
                 console.log('[VIEWER] Connection to master successful!');
                 const stats = await viewer.peerConnection.getStats();

--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -113,7 +113,7 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, onR
         }
 
         // Poll for connection stats
-        viewer.peerConnectionStatsInterval = setInterval(() => viewer.peerConnection.getStats().then(onStatsReport), 1000);
+        viewer.peerConnectionStatsInterval = setInterval(() => viewer.peerConnection.getStats().then(onStatsReport), 10000);
 
         viewer.signalingClient.on('open', async () => {
             console.log('[VIEWER] Connected to signaling service');
@@ -144,6 +144,7 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, onR
             // When trickle ICE is enabled, send the offer now and then send ICE candidates as they are generated. Otherwise wait on the ICE candidates.
             if (formValues.useTrickleICE) {
                 console.log('[VIEWER] Sending SDP offer');
+                console.debug('SDP offer:', viewer.peerConnection.localDescription);
                 viewer.signalingClient.sendSdpOffer(viewer.peerConnection.localDescription);
             }
             console.log('[VIEWER] Generating ICE candidates');
@@ -152,12 +153,14 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, onR
         viewer.signalingClient.on('sdpAnswer', async answer => {
             // Add the SDP answer to the peer connection
             console.log('[VIEWER] Received SDP answer');
+            console.debug('SDP answer:', answer);
             await viewer.peerConnection.setRemoteDescription(answer);
         });
 
         viewer.signalingClient.on('iceCandidate', candidate => {
             // Add the ICE candidate received from the MASTER to the peer connection
             console.log('[VIEWER] Received ICE candidate');
+            console.debug('ICE candidate', candidate);
             viewer.peerConnection.addIceCandidate(candidate);
         });
 
@@ -173,6 +176,7 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, onR
         viewer.peerConnection.addEventListener('icecandidate', ({ candidate }) => {
             if (candidate) {
                 console.log('[VIEWER] Generated ICE candidate');
+                console.debug('ICE candidate:', candidate);
 
                 // When trickle ICE is enabled, send the ICE candidates as they are generated.
                 if (formValues.useTrickleICE) {
@@ -185,6 +189,7 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, onR
                 // When trickle ICE is disabled, send the offer now that all the ICE candidates have ben generated.
                 if (!formValues.useTrickleICE) {
                     console.log('[VIEWER] Sending SDP offer');
+                    console.debug('SDP offer:', peerConnection.localDescription);
                     viewer.signalingClient.sendSdpOffer(viewer.peerConnection.localDescription);
                 }
             }

--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -196,39 +196,7 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, onR
         });
 
         viewer.peerConnection.addEventListener('connectionstatechange', async event => {
-            console.debug('[VIEWER] PeerConnection state:', viewer.peerConnection.connectionState);
-
-            if (viewer.peerConnection.connectionState === 'connected') {
-                console.log('[VIEWER] Connection to master successful!');
-                const stats = await viewer.peerConnection.getStats();
-                if (!stats) return;
-
-                let selectedPairId = null;
-                for (const [, stat] of stats) {
-                    if (stat.type === 'transport') {
-                        selectedPairId = stat.selectedCandidatePairId;
-                        break;
-                    }
-                }
-
-                let candidatePair = stats.get(selectedPairId);
-                if (!candidatePair) {
-                    for (const [, stat] of stats) {
-                        if (stat.type === 'candidate-pair' && stat.selected) {
-                            candidatePair = stat;
-                            break;
-                        }
-                    }
-                }
-
-                if (candidatePair) {
-                    console.debug('[VIEWER] Chosen pair:', candidatePair);
-                    console.debug('remote candidate:', stats.get(candidatePair.remoteCandidateId));
-                    console.debug('local candidate:', stats.get(candidatePair.localCandidateId));
-                }
-            } else if (viewer.peerConnection.connectionState === 'failed') {
-                console.error('[VIEWER] Connection to master failed!');
-            }
+            printPeerConnectionStateInfo(event, '[VIEWER]');
         });
 
         // As remote tracks are received, add them to the remote view

--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -195,6 +195,40 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, onR
             }
         });
 
+        viewer.peerConnection.addEventListener('connectionstatechange', async event => {
+            if (viewer.peerConnection.connectionState === 'connected') {
+                console.log('[VIEWER] Connection to master successful!');
+                const stats = await viewer.peerConnection.getStats();
+                if (!stats) return;
+
+                let selectedPairId = null;
+                for (const [, stat] of stats) {
+                    if (stat.type === 'transport') {
+                        selectedPairId = stat.selectedCandidatePairId;
+                        break;
+                    }
+                }
+
+                let candidatePair = stats.get(selectedPairId);
+                if (!candidatePair) {
+                    for (const [, stat] of stats) {
+                        if (stat.type === 'candidate-pair' && stat.selected) {
+                            candidatePair = stat;
+                            break;
+                        }
+                    }
+                }
+
+                if (candidatePair) {
+                    console.debug('[VIEWER] Chosen pair:', candidatePair);
+                    console.debug('remote candidate:', stats.get(candidatePair.remoteCandidateId));
+                    console.debug('local candidate:', stats.get(candidatePair.localCandidateId));
+                }
+            } else if (viewer.peerConnection.connectionState === 'failed') {
+                console.error('[VIEWER] Connection to master failed!');
+            }
+        });
+
         // As remote tracks are received, add them to the remote view
         viewer.peerConnection.addEventListener('track', event => {
             console.log('[VIEWER] Received remote track');

--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -5,6 +5,8 @@ const viewer = {};
 
 async function startViewer(localView, remoteView, formValues, onStatsReport, onRemoteDataMessage) {
     try {
+        console.log('[VIEWER] Client id is:', formValues.clientId);
+
         viewer.localView = localView;
         viewer.remoteView = remoteView;
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Master now can show multiple viewers
<img width="1173" alt="image" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/assets/14988194/e6e613e1-740e-459e-82c4-b49b4d6ce19c">

(pictured above: master and two viewers, with the mock video source: `open -a "Google Chrome" --args --use-fake-device-for-media-stream`. Make sure chrome is not running before launching otherwise the webcam might still show.)

* High-level overview 
  * When a new viewer connects, a new video element is added to the page, below the previous one.
  * When the peer connection moves to the FAILED state, the video element is removed from the page.
  * The viewer's `ClientId` is added below each video's media tracks.
  * When the master has no viewers connected, an empty video player will be shown.

* Add DEBUG log level
<img width="1191" alt="image" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/assets/14988194/08aefdc7-cb9c-4a1d-a632-0edda3646269">

* log SDP offer and answer in DEBUG
* log generated ICE candidates in DEBUG
* log selected ice candidate in DEBUG
* log when the peer connection is successful or unsuccessful in DEBUG
* Add tooltip for ICE Candidate generation
<img width="454" alt="image" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/assets/14988194/3fbcbc41-73af-4ab2-b2ef-166712f2f456">

<img width="338" alt="image" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/assets/14988194/38d163c3-650c-4e88-bc34-d1955f17fcc1">

-------
Fixed an issue with "Enable KVS WebRTC DQP Test and Metrics (Viewer only)" if the `ClientId` is empty, the display would generate a new one with each update.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
