### PR TITLE
Adds STUN only option on WebRTC test page

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -73,6 +73,7 @@ function getFormValues() {
         fullscreen: $('#fullscreen').is(':checked'),
         useTrickleICE: $('#useTrickleICE').is(':checked'),
         natTraversalDisabled: $('#natTraversalDisabled').is(':checked'),
+        forceSTUN: $('#forceSTUN').is(':checked'),
         forceTURN: $('#forceTURN').is(':checked'),
         accessKeyId: $('#accessKeyId').val(),
         endpoint: $('#endpoint').val() || null,

--- a/examples/app.js
+++ b/examples/app.js
@@ -373,6 +373,7 @@ const fields = [
     { field: 'openDataChannel', type: 'checkbox' },
     { field: 'useTrickleICE', type: 'checkbox' },
     { field: 'natTraversalEnabled', type: 'radio', name: 'natTraversal' },
+    { field: 'forceSTUN', type: 'radio', name: 'natTraversal' },
     { field: 'forceTURN', type: 'radio', name: 'natTraversal' },
     { field: 'natTraversalDisabled', type: 'radio', name: 'natTraversal' },
     { field: 'ingestMedia', type: 'checkbox' },

--- a/examples/index.html
+++ b/examples/index.html
@@ -112,6 +112,10 @@
                     <label class="form-check-label" for="forceTURN">TURN Only <small>(force cloud relay)</small></label>
                 </div>
                 <div class="form-check form-check">
+                    <input class="form-check-input" type="radio" name="natTraversal" id="forceSTUN" value="option4">
+                    <label class="form-check-label" for="forceSTUN">STUN Only</label>
+                </div>
+                <div class="form-check form-check">
                     <input class="form-check-input" type="radio" name="natTraversal" id="natTraversalDisabled" value="option1">
                     <label class="form-check-label" for="natTraversalDisabled">Disabled</label>
                 </div>

--- a/examples/master.js
+++ b/examples/master.js
@@ -123,10 +123,13 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
             })
             .promise();
         const iceServers = [];
+        // Don't add stun if user selects TURN only or NAT traversal disabled
         if (!formValues.natTraversalDisabled && !formValues.forceTURN) {
             iceServers.push({ urls: `stun:stun.kinesisvideo.${formValues.region}.amazonaws.com:443` });
         }
-        if (!formValues.natTraversalDisabled) {
+
+        // Add TURN only if user does not select NAT traversal disabled and STUN only mode
+        if (!formValues.natTraversalDisabled && !formValues.forceSTUN) {
             getIceServerConfigResponse.IceServerList.forEach(iceServer =>
                 iceServers.push({
                     urls: iceServer.Uris,

--- a/examples/master.js
+++ b/examples/master.js
@@ -128,7 +128,7 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
             iceServers.push({ urls: `stun:stun.kinesisvideo.${formValues.region}.amazonaws.com:443` });
         }
 
-        // Add TURN only if user does not select NAT traversal disabled and STUN only mode
+        // Don't add turn if user selects STUN only or NAT traversal disabled
         if (!formValues.natTraversalDisabled && !formValues.forceSTUN) {
             getIceServerConfigResponse.IceServerList.forEach(iceServer =>
                 iceServers.push({

--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -161,7 +161,7 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, onR
             iceServers.push({ urls: `stun:stun.kinesisvideo.${formValues.region}.amazonaws.com:443` });
         }
 
-        // Add TURN only if user does not select NAT traversal disabled and STUN only mode
+        // Don't add turn if user selects STUN only or NAT traversal disabled
         if (!formValues.natTraversalDisabled && !formValues.forceSTUN) {
             getIceServerConfigResponse.IceServerList.forEach(iceServer =>
                 iceServers.push({

--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -156,10 +156,13 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, onR
             })
             .promise();
         const iceServers = [];
+        // Don't add stun if user selects TURN only or NAT traversal disabled
         if (!formValues.natTraversalDisabled && !formValues.forceTURN) {
             iceServers.push({ urls: `stun:stun.kinesisvideo.${formValues.region}.amazonaws.com:443` });
         }
-        if (!formValues.natTraversalDisabled) {
+
+        // Add TURN only if user does not select NAT traversal disabled and STUN only mode
+        if (!formValues.natTraversalDisabled && !formValues.forceSTUN) {
             getIceServerConfigResponse.IceServerList.forEach(iceServer =>
                 iceServers.push({
                     urls: iceServer.Uris,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds STUN only option on WebRTC test page. Helps with testing from behind a router (using STUN) on public internet (without TURN).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
