### PR TITLE
Add callback for self-created data channel

### DIFF
--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -207,7 +207,10 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, onR
         viewer.peerConnection = new RTCPeerConnection(configuration);
         if (formValues.openDataChannel) {
             viewer.dataChannel = viewer.peerConnection.createDataChannel('kvsDataChannel');
+            // Callback for the data channel created by viewer
+            viewer.dataChannel.onmessage = onRemoteDataMessage;
             viewer.peerConnection.ondatachannel = event => {
+                // Callback for the data channel created by master
                 event.channel.onmessage = onRemoteDataMessage;
             };
         }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/1752

*Description of changes:* In case of using C SDK master and JS SDK viewer, C SDK will send back a message on the data channel created by JS SDK viewer. However, JS SDK viewer doesn't have a callback function to the data channel created by itself. This behavior is confusing for users not familiar with WebRTC.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
