### PR TITLE
Sample QoL: Add button to copy logs

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -7,7 +7,7 @@ function configureLogging() {
         const text = messages
             .map(message => {
                 if (message instanceof Error) {
-                    const {stack, ...rest} = message;
+                    const { stack, ...rest } = message;
                     if (Object.keys(rest).length === 0) {
                         if (stack) {
                             return stack;
@@ -36,25 +36,25 @@ function configureLogging() {
     }
 
     console._error = console.error;
-    console.error = function (...rest) {
+    console.error = function(...rest) {
         log('ERROR', Array.prototype.slice.call(rest));
         console._error.apply(this, rest);
     };
 
     console._warn = console.warn;
-    console.warn = function (...rest) {
+    console.warn = function(...rest) {
         log('WARN', Array.prototype.slice.call(rest));
         console._warn.apply(this, rest);
     };
 
     console._log = console.log;
-    console.log = function (...rest) {
+    console.log = function(...rest) {
         log('INFO', Array.prototype.slice.call(rest));
         console._log.apply(this, rest);
     };
 
     console._debug = console.debug;
-    console.debug = function (...rest) {
+    console.debug = function(...rest) {
         log('DEBUG', Array.prototype.slice.call(rest));
         console._debug.apply(this, rest);
     };
@@ -127,12 +127,12 @@ function onStop() {
 
 window.addEventListener('beforeunload', onStop);
 
-window.addEventListener('error', function (event) {
+window.addEventListener('error', function(event) {
     console.error(event.message);
     event.preventDefault();
 });
 
-window.addEventListener('unhandledrejection', function (event) {
+window.addEventListener('unhandledrejection', function(event) {
     console.error(event.reason.toString());
     event.preventDefault();
 });
@@ -425,26 +425,26 @@ $('#ingestMedia').click(() => {
 // Read/Write all of the fields to/from localStorage so that fields are not lost on refresh.
 const urlParams = new URLSearchParams(window.location.search);
 const fields = [
-    {field: 'channelName', type: 'text'},
-    {field: 'clientId', type: 'text'},
-    {field: 'region', type: 'text'},
-    {field: 'accessKeyId', type: 'text'},
-    {field: 'secretAccessKey', type: 'text'},
-    {field: 'sessionToken', type: 'text'},
-    {field: 'endpoint', type: 'text'},
-    {field: 'sendVideo', type: 'checkbox'},
-    {field: 'sendAudio', type: 'checkbox'},
-    {field: 'widescreen', type: 'radio', name: 'resolution'},
-    {field: 'fullscreen', type: 'radio', name: 'resolution'},
-    {field: 'openDataChannel', type: 'checkbox'},
-    {field: 'useTrickleICE', type: 'checkbox'},
-    {field: 'natTraversalEnabled', type: 'radio', name: 'natTraversal'},
-    {field: 'forceSTUN', type: 'radio', name: 'natTraversal'},
-    {field: 'forceTURN', type: 'radio', name: 'natTraversal'},
-    {field: 'natTraversalDisabled', type: 'radio', name: 'natTraversal'},
-    {field: 'ingestMedia', type: 'checkbox'},
+    { field: 'channelName', type: 'text' },
+    { field: 'clientId', type: 'text' },
+    { field: 'region', type: 'text' },
+    { field: 'accessKeyId', type: 'text' },
+    { field: 'secretAccessKey', type: 'text' },
+    { field: 'sessionToken', type: 'text' },
+    { field: 'endpoint', type: 'text' },
+    { field: 'sendVideo', type: 'checkbox' },
+    { field: 'sendAudio', type: 'checkbox' },
+    { field: 'widescreen', type: 'radio', name: 'resolution' },
+    { field: 'fullscreen', type: 'radio', name: 'resolution' },
+    { field: 'openDataChannel', type: 'checkbox' },
+    { field: 'useTrickleICE', type: 'checkbox' },
+    { field: 'natTraversalEnabled', type: 'radio', name: 'natTraversal' },
+    { field: 'forceSTUN', type: 'radio', name: 'natTraversal' },
+    { field: 'forceTURN', type: 'radio', name: 'natTraversal' },
+    { field: 'natTraversalDisabled', type: 'radio', name: 'natTraversal' },
+    { field: 'ingestMedia', type: 'checkbox' },
 ];
-fields.forEach(({field, type, name}) => {
+fields.forEach(({ field, type, name }) => {
     const id = '#' + field;
 
     // Read field from localStorage
@@ -473,7 +473,7 @@ fields.forEach(({field, type, name}) => {
     }
 
     // Write field to localstorage on change event
-    $(id).change(function () {
+    $(id).change(function() {
         try {
             if (type === 'checkbox') {
                 localStorage.setItem(field, $(id).is(':checked'));
@@ -492,9 +492,31 @@ fields.forEach(({field, type, name}) => {
     });
 });
 
+$('#copy-logs').on('click', async function() {
+    const logsResult = [];
+    $('#logs')
+        .children()
+        // Only copy the logs that are visible
+        .filter((_, element) => !element.getAttribute('class')?.includes('d-none'))
+        .each(function() {
+            logsResult.push(this.textContent);
+        });
+    navigator.clipboard.writeText(logsResult.join(''));
+    $('#copy-tooltip').tooltip('show');
+    $('#copy-logs').removeClass('btn-light');
+    $('#copy-logs').addClass('btn-success');
+    await new Promise(r => setTimeout(r, 1000));
+    $('#copy-tooltip').tooltip('hide');
+    $('#copy-logs').removeClass('btn-success');
+    $('#copy-logs').addClass('btn-light');
+});
+
 // Enable tooltips
-$(document).ready(function () {
+$(document).ready(function() {
     $('[data-toggle="tooltip"]').tooltip();
+
+    // Except the copy-logs tooltip
+    $('#copy-tooltip').tooltip({ trigger: 'manual' });
 });
 
 // The page is all setup. Hide the loading spinner and show the page content.

--- a/examples/index.html
+++ b/examples/index.html
@@ -249,10 +249,15 @@
                     <button id="warn-button" class="btn btn-light" onClick="logLevelSelected(event)" data-level="WARN">WARN</button>
                     <button id="error-button" class="btn btn-light" onClick="logLevelSelected(event)" data-level="ERROR">ERROR</button>
                 </div>
-                <div>
+                <div class="d-inline-flex">
                     <button id="more-logs" class="btn btn-light" title="Show more logs">+</button>
                     <button id="less-logs" class="btn btn-light" title="Show less logs">-</button>
                     <button id="clear-logs" class="btn btn-light">Clear Logs</button>
+                    <div>
+                        <button id="copy-logs" class="btn btn-light" title="Copy logs">
+                            <span id="copy-tooltip" aria-live="assertive" class="text-info" role="tooltip" data-position="auto" title="Copied logs to clipboard!">📋</span>
+                        </button>
+                    </div>
                 </div>
             </div>
             <pre id="logs" class="card-body text-monospace preserve-whitespace"></pre>


### PR DESCRIPTION
## What was changed?

The sample. Added a button to copy the logs.
<img width="259" alt="image" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/assets/14988194/185fc31a-0349-4a1f-93c5-58a1c7d2985c">

It also has a tooltip:
<img width="153" alt="image" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/assets/14988194/ae31f8a5-d422-4bf7-b4fd-325424a82717">

And, when you click on it, the button changes colors and displays a message!
<img width="236" alt="image" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/assets/14988194/cb16b70d-fa68-4870-a11f-5caca0603b8a">

## Why was it changed?

I (and probably many users) need to copy/paste the logs. Using Ctrl+A selects too much stuff, and scrolling up and down the page is a lot of effort. I added this button to make it easier and quicker to copy/paste the logs.

## How was it changed?

When the button is clicked, it loops through all of the children inside of the log container. It grabs the visible elements, appends them together, and adds it to your clipboard.

## Testing:

I clicked the button in the following cases:
1. When there are no logs. I pasted my clipboard into a text editor and it was empty.
2. When there are logs with an exception, INFO selected. I pasted my clipboard into a text editor and the full logs are copied.
3. When there are logs with an exception, ERROR selected. I pasted my clipboard into a text editor are none of the INFO logs show up.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.