### PR TITLE
Add null check for sender.transport.iceTransport

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -369,9 +369,12 @@ async function printPeerConnectionStateInfo(event, logPrefix, remoteClientId) {
             const trackType = sender.track?.kind;
             if (sender.transport) {
                 const iceTransport = sender.transport.iceTransport;
-                const logSelectedCandidate = () => console.debug(`Chosen candidate pair (${trackType || 'unknown'}):`, iceTransport.getSelectedCandidatePair());
-                iceTransport.onselectedcandidatepairchange = logSelectedCandidate;
-                logSelectedCandidate();
+                if (iceTransport) {
+                    const logSelectedCandidate = () =>
+                        console.debug(`Chosen candidate pair (${trackType || 'unknown'}):`, iceTransport.getSelectedCandidatePair());
+                    iceTransport.onselectedcandidatepairchange = logSelectedCandidate;
+                    logSelectedCandidate();
+                }
             } else {
                 console.error('Failed to fetch the candidate pair!');
             }


### PR DESCRIPTION
### What is the issue?
* While testing this on Firefox, and using the [Android WebRTC Sample](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-android), we saw the following log line:
```
TypeError: iceTransport is undefined
```

I added a debug print statement to print the selected ICE Candidate pair. It seems that this method of printing the selected pair is not available in Firefox, and the property is not available, resulting in a null pointer exception.

This only appears in Firefox. Chrome and Safari work fine.

### How was this fixed?
* Add a null check and exit if we cannot print the selected ice candidate pair.

### Testing
* Run this with the Firefox + Android combo, and the error no longer gets printed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
