### PR TITLE
sample: ingestion feature off by default

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -103,7 +103,7 @@
                     <p><small>List storage channels outputs the ARNs of all signaling channels configured for storage and their associated stream's ARN.</small></p>
                 </div>
                 <div class="form-group form-check form-check-inline">
-                    <input class="form-check-input" type="checkbox" id="ingest-media" value="audio" checked>
+                    <input class="form-check-input" type="checkbox" id="ingest-media" value="audio">
                     <label for="sendAudio" class="form-check-label"><i>Ingestion and storage peer</i> joins automatically</label>
                     <span data-delay="{ &quot;hide&quot;: 1500 }" data-position="auto" tabindex="0" class="text-info ml-1" data-toggle="tooltip" data-html="true" title="
                     <p>If WebRTC Ingestion and Storage is configured, after connecting to Kinesis Video Signaling, this sample application will invoke the JoinStorageSession API to have the Kinesis video producing device join the WebRTC session as a viewer.</p>

--- a/examples/master.js
+++ b/examples/master.js
@@ -74,7 +74,7 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
 
         const protocols = ['WSS', 'HTTPS'];
 
-        if (formValues.region?.toLowerCase() === 'us-west-2') {
+        if (formValues.region?.toLowerCase() === 'us-west-2' && formValues.ingestMedia) {
             console.log('[MASTER] Attempting to use media ingestion feature.');
             const describeMediaStorageConfigurationResponse = await kinesisVideoClient
                 .describeMediaStorageConfiguration({
@@ -353,7 +353,7 @@ function onPeerConnectionFailed() {
         if (!master.websocketOpened) {
             console.log('[MASTER] Websocket is closed. Reopening...');
             master.signalingClient.open();
-        } else if (getFormValues().ingestMedia) {
+        } else if (master.streamARN) {
             connectToMediaServer(++master.runId);
         }
     }

--- a/examples/master.js
+++ b/examples/master.js
@@ -75,7 +75,7 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
         const protocols = ['WSS', 'HTTPS'];
 
         if (formValues.region?.toLowerCase() === 'us-west-2' && formValues.ingestMedia) {
-            console.log('[MASTER] Attempting to use media ingestion feature.');
+            console.log('[MASTER] Determining whether to use media ingestion feature.');
             const describeMediaStorageConfigurationResponse = await kinesisVideoClient
                 .describeMediaStorageConfiguration({
                     ChannelARN: master.channelARN,
@@ -217,7 +217,7 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
                     console.log('[MASTER] Waiting for media ingestion and storage viewer to join...');
                 }
             } else {
-                console.log('[MASTER] Media ingestion and storage is not enabled for this channel. Waiting for peers to join...');
+                console.log('[MASTER] Waiting for peers to join...');
             }
         });
 

--- a/examples/master.js
+++ b/examples/master.js
@@ -353,7 +353,7 @@ function onPeerConnectionFailed() {
         if (!master.websocketOpened) {
             console.log('[MASTER] Websocket is closed. Reopening...');
             master.signalingClient.open();
-        } else if (master.streamARN) {
+        } else {
             connectToMediaServer(++master.runId);
         }
     }

--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -127,7 +127,7 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, onR
         console.log('[VIEWER] Channel ARN:', channelARN);
 
         if (formValues.region?.toLowerCase() === 'us-west-2' && formValues.ingestMedia) {
-            console.log('[VIEWER] Using media ingestion feature');
+            console.log('[VIEWER] Determining whether this signaling channel is in media ingestion mode.');
             const mediaStorageConfiguration = await kinesisVideoClient
                 .describeMediaStorageConfiguration({
                     ChannelName: formValues.channelName,

--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -126,15 +126,22 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, onR
         const channelARN = describeSignalingChannelResponse.ChannelInfo.ChannelARN;
         console.log('[VIEWER] Channel ARN:', channelARN);
 
-        const mediaStorageConfiguration = await kinesisVideoClient
-            .describeMediaStorageConfiguration({
-                ChannelName: formValues.channelName,
-            })
-            .promise();
+        if (formValues.region?.toLowerCase() === 'us-west-2') {
+            console.log('[VIEWER] Using media ingestion feature');
+            const mediaStorageConfiguration = await kinesisVideoClient
+                .describeMediaStorageConfiguration({
+                    ChannelName: formValues.channelName,
+                })
+                .promise();
 
-        if (mediaStorageConfiguration.MediaStorageConfiguration.Status !== 'DISABLED') {
-            console.error('[VIEWER] Media storage and ingestion is ENABLED for this channel. Only the WebRTC Ingestion and Storage peer can join as a viewer.');
-            return;
+            if (mediaStorageConfiguration.MediaStorageConfiguration.Status !== 'DISABLED') {
+                console.error(
+                    '[VIEWER] Media storage and ingestion is ENABLED for this channel. Only the WebRTC Ingestion and Storage peer can join as a viewer.',
+                );
+                return;
+            }
+        } else {
+            console.log('[VIEWER] Not using media ingestion feature');
         }
 
         // Get signaling channel endpoints

--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -126,7 +126,7 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, onR
         const channelARN = describeSignalingChannelResponse.ChannelInfo.ChannelARN;
         console.log('[VIEWER] Channel ARN:', channelARN);
 
-        if (formValues.region?.toLowerCase() === 'us-west-2') {
+        if (formValues.region?.toLowerCase() === 'us-west-2' && formValues.ingestMedia) {
             console.log('[VIEWER] Using media ingestion feature');
             const mediaStorageConfiguration = await kinesisVideoClient
                 .describeMediaStorageConfiguration({


### PR DESCRIPTION
## What was changed?
The way the sample determines which mode to run in: Regular WebRTC, or [WebRTC Ingestion](https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/webrtc-ingestion.html) mode.

This will only impact users in the `us-west-2` (preview) region.

## How/why was it changed?
When using _automatic mode detection_, the sample will use [DescribeMediaStorageConfiguration](https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/webrtc-ingestion.html) for users in `us-west-2` to determine which mode to run in. Previously, _automatic mode detection_ would be enabled by default. The checkbox enabling the _automatic mode detection_ is now unchecked by default, skipping the `DescribeMediaStorageConfiguration` API call.

If you want to try the WebRTC ingestion feature, you will need to manually enable the checkbox, and use the `us-west-2` region.

## Testing
* Tested the sample in both `us-west-2` (media ingestion feature + regular P2P) and `us-east-1` (regular P2P) using a non-dev account. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
