### PR TITLE
sample: Add manual joinstoragesession button & reduce retry delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,19 @@ Emitted when a new SDP answer is received over the channel. Typically only a vie
 
 Emitted when a new ICE candidate is received over the channel.
 
+#### Event: `'statusResponse'`
+* `statusResponse` {statusResponse} The [status response](https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/kvswebrtc-websocket-apis-7.html) received from the signaling service.
+
+Emitted when a statusResponse is received over the channel.
+
+* `statusResponse` {object}
+    * `correlationId` {string} `correlationId` of the message for which the status is meant.
+    * `success` {boolean} Whether this `statusResponse` is a success or failure. (Currently, these responses are only sent on failures.)
+    * `errorType` {optional string} A name to uniquely identify the error.
+    * `statusCode` {optional string} HTTP status code corresponding to the nature of the response.
+    * `description` {optional string} A string description explaining the status.
+
+
 #### Event: `'close'`
 Emitted when the connection to the signaling service is closed. Even if there is an error, as long as the connection is closed, this event will be emitted.
 
@@ -305,17 +318,20 @@ Opens a connection to the signaling service. An error will be thrown if there is
 #### Method: `close()`
 Closes the active connection to the signaling service. Nothing will happen if there is no open connection.
 
-#### Method: `sendSdpOffer(sdpOffer, [recipientClientId])`
+#### Method: `sendSdpOffer(sdpOffer, [recipientClientId, correlationId])`
 * `sdpOffer` {[RTCSessionDescription](https://developer.mozilla.org/en-US/docs/Web/API/RTCSessionDescription)} SDP offer to send to the recipient client.
 * `recipientClientId` {string} The id of the client to send the SDP offer to. If no id is provided, it will be sent to the master.
+* `correlationId` {string} A unique identifier for this message. If there was an error with this message, Signaling will send a failure StatusResponse with the same correlationId.
 
-#### Method: `sendSdpAnswer(sdpAnswer, [recipientClientId])`
+#### Method: `sendSdpAnswer(sdpAnswer, [recipientClientId, correlationId])`
 * `sdpAnswer` {[RTCSessionDescription](https://developer.mozilla.org/en-US/docs/Web/API/RTCSessionDescription)} SDP answer to send to the recipient client.
 * `recipientClientId` {string} The id of the client to send the SDP answer to. If no id is provided, it will be sent to the master.
+* `correlationId` {string} A unique identifier for this message. If there was an error with this message, Signaling will send a failure StatusResponse with the same correlationId.
 
-#### Method: `sendIceCandidate(iceCandidate, [recipientClientId])`
+#### Method: `sendIceCandidate(iceCandidate, [recipientClientId, correlationId])`
 * `iceCandidate` {[RTCIceCandidate](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate)} ICE candidate to send to the recipient client.
 * `recipientClientId` {string} The id of the client to send the ICE candidate to. If no id is provided, it will be sent to the master.
+* `correlationId` {string} A unique identifier for this message. If there was an error with this message, Signaling will send a failure StatusResponse with the same correlationId.
 
 ### Interface: `RequestSigner`
 Interface for signing HTTP and WebSocket requests.

--- a/examples/app.css
+++ b/examples/app.css
@@ -26,7 +26,7 @@ pre .warn {
     color: goldenrod;
 }
 
-#debug pre {
+#logs {
     height: 500px;
     overflow: auto;
 }

--- a/examples/app.js
+++ b/examples/app.js
@@ -125,6 +125,8 @@ function onStop() {
     if (ROLE === 'master') {
         stopMaster();
         $('#master').addClass('d-none');
+        $('#master .remote-view').removeClass('d-none');
+        $('#master .remote').removeClass('d-none');
     } else {
         stopViewer();
         $('#viewer').addClass('d-none');

--- a/examples/app.js
+++ b/examples/app.js
@@ -615,6 +615,10 @@ function shouldSendIceCandidate(formValues, candidate) {
     }
 }
 
+function randomString() {
+    return Date.now().toString();
+}
+
 function extractTransportAndType(candidate) {
     const words = candidate.candidate.split(' ');
 

--- a/examples/app.js
+++ b/examples/app.js
@@ -76,6 +76,7 @@ function getFormValues() {
         sendAudio: $('#sendAudio').is(':checked'),
         streamName: $('#streamName').val(),
         ingestMedia: $('#ingest-media').is(':checked'),
+        showJSSButton: $('#show-join-storage-session-button').is(':checked'),
         openDataChannel: $('#openDataChannel').is(':checked'),
         widescreen: $('#widescreen').is(':checked'),
         fullscreen: $('#fullscreen').is(':checked'),
@@ -135,6 +136,7 @@ function onStop() {
     }
 
     $('#form').removeClass('d-none');
+    $('#join-storage-session-button').addClass('d-none');
     ROLE = null;
 }
 
@@ -414,6 +416,7 @@ const fields = [
     { field: 'sendAudio', type: 'checkbox' },
     { field: 'streamName', type: 'text' },
     { field: 'ingest-media', type: 'checkbox' },
+    { field: 'show-join-storage-session-button', type: 'checkbox' },
     { field: 'widescreen', type: 'radio', name: 'resolution' },
     { field: 'fullscreen', type: 'radio', name: 'resolution' },
     { field: 'openDataChannel', type: 'checkbox' },
@@ -669,6 +672,11 @@ $('#create-stream-modal-create-stream-button').on('click', async function() {
         streamName: $('#create-stream-modal-stream-input').val(),
         retentionInHours: $('#create-stream-modal-retention-input').val(),
     });
+});
+
+$('#join-storage-session-button').on('click', async function() {
+    const formValues = getFormValues();
+    joinStorageSessionManually(formValues);
 });
 
 // Enable tooltips

--- a/examples/index.html
+++ b/examples/index.html
@@ -106,7 +106,7 @@
                     <p><small>List storage channels outputs the ARNs of all signaling channels configured for storage and their associated stream's ARN.</small></p>
                 </div>
                 <div class="form-group form-check form-check-inline">
-                    <input class="form-check-input" type="checkbox" id="ingest-media" value="audio">
+                    <input class="form-check-input" type="checkbox" id="ingest-media">
                     <label for="ingest-media" class="form-check-label"><i>Ingestion and storage peer</i> joins automatically</label>
                     <span data-delay="{ &quot;hide&quot;: 1500 }" data-position="auto" tabindex="0" class="text-info ml-1" data-toggle="tooltip" data-html="true" title="
                     <p>If WebRTC Ingestion and Storage is configured, after connecting to Kinesis Video Signaling, this sample application will invoke the JoinStorageSession API to have the Kinesis video producing device join the WebRTC session as a viewer.</p>
@@ -114,8 +114,8 @@
                     "><sup>&#9432;</sup></span>
                 </div>
                 <div class="form-group form-check form-check-inline">
-                    <input class="form-check-input" type="checkbox" id="show-join-storage-session-button" value="audio">
-                    <label for="sendAudio" class="form-check-label">Show button to manually call JoinStorageSession API.</label></span>
+                    <input class="form-check-input" type="checkbox" id="show-join-storage-session-button">
+                    <label for="show-join-storage-session-button" class="form-check-label">Show button to manually call JoinStorageSession API.</label></span>
                 </div>
             </div>
             </details>

--- a/examples/index.html
+++ b/examples/index.html
@@ -113,6 +113,10 @@
                     <a href=&quot;https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/API_webrtc_JoinStorageSession.html&quot;>Additional information</a>
                     "><sup>&#9432;</sup></span>
                 </div>
+                <div class="form-group form-check form-check-inline">
+                    <input class="form-check-input" type="checkbox" id="show-join-storage-session-button" value="audio">
+                    <label for="sendAudio" class="form-check-label">Show button to manually call JoinStorageSession API.</label></span>
+                </div>
             </div>
             </details>
             <h4>Video Resolution</h4>
@@ -298,6 +302,7 @@
                   <button id="send-message" type="button" class="btn btn-primary">Send DataChannel Message</button>
                 </span>
                 <button id="stop-master-button" type="button" class="btn btn-primary">Stop Master</button>
+                <button id="join-storage-session-button" type="button" class="btn btn-primary d-none">Join Storage Session</button>
             </div>
         </div>
 
@@ -388,6 +393,7 @@
 <script src="./updateMediaStorageConfiguration.js"></script>
 <script src="./describeMediaStorageConfiguration.js"></script>
 <script src="./createStream.js"></script>
+<script src="./joinStorageSession.js"></script>
 <script src="./app.js"></script>
 
 </body>

--- a/examples/index.html
+++ b/examples/index.html
@@ -301,7 +301,7 @@
                 <span class="send-message datachannel">
                   <button id="send-message" type="button" class="btn btn-primary">Send DataChannel Message</button>
                 </span>
-                <button id="stop-master-button" type="button" class="btn btn-primary">Stop Master</button>
+                <button id="stop-master-button" type="button" class="btn btn-danger">Stop Master</button>
                 <button id="join-storage-session-button" type="button" class="btn btn-primary d-none">Join Storage Session</button>
             </div>
         </div>
@@ -334,7 +334,7 @@
                 <span class="send-message datachannel d-none">
                   <button type="button" class="btn btn-primary">Send DataChannel Message</button>
                 </span>
-                <button id="stop-viewer-button" type="button" class="btn btn-primary">Stop Viewer</button>
+                <button id="stop-viewer-button" type="button" class="btn btn-danger">Stop Viewer</button>
             </div>
         </div>
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -280,7 +280,7 @@
                     <h5>Master Section</h5>
                     <div class="video-container"><video class="local-view" autoplay playsinline controls muted></video></div>
                 </div>
-                <div id="viewer-view-holder" class="col">
+                <div id="viewer-view-holder" class="col remote">
                     <h5>Viewer Return Channel</h5>
                     <div id="empty-video-placeholder" class="video-container"><video class="remote-view" autoplay playsinline controls></video></div>
                 </div>
@@ -291,7 +291,7 @@
                       <textarea type="text" class="form-control local-message" placeholder="DataChannel message to send to all viewers"> </textarea>
                     </div>
                 </div>
-                <div class="col">
+                <div class="col remote">
                     <div class="card bg-light mb-3">
                         <pre class="remote-message card-body text-monospace preserve-whitespace"></pre>
                     </div>

--- a/examples/joinStorageSession.js
+++ b/examples/joinStorageSession.js
@@ -1,0 +1,64 @@
+/**
+ * This function calls joinStorageSession.
+ */
+async function joinStorageSessionManually(formValues) {
+    $('#logs-header')[0].scrollIntoView({
+        block: 'start',
+    });
+
+    try {
+        console.log('[JOIN_STORAGE_SESSION] Calling JoinStorageSession for channel', formValues.channelName);
+
+        // Create KVS client
+        const kinesisVideoClient = new AWS.KinesisVideo({
+            region: formValues.region,
+            accessKeyId: formValues.accessKeyId,
+            secretAccessKey: formValues.secretAccessKey,
+            sessionToken: formValues.sessionToken,
+            endpoint: formValues.endpoint,
+        });
+
+        // Step 1: Obtain the ARN of the Signaling Channel
+        const describeSignalingChannelResponse = await kinesisVideoClient
+            .describeSignalingChannel({
+                ChannelName: formValues.channelName,
+            })
+            .promise();
+        const channelARN = describeSignalingChannelResponse.ChannelInfo.ChannelARN;
+
+        // Step 2: Obtain the WEBRTC endpoint
+        const getSignalingChannelEndpointResponse = await kinesisVideoClient
+            .getSignalingChannelEndpoint({
+                ChannelARN: channelARN,
+                SingleMasterChannelEndpointConfiguration: {
+                    Protocols: ['WEBRTC'],
+                    Role: KVSWebRTC.Role.VIEWER,
+                },
+            })
+            .promise();
+        const webrtcEndpoint = getSignalingChannelEndpointResponse.ResourceEndpointList[0].ResourceEndpoint;
+
+        const kinesisVideoClientWebRTCStorageClient = new AWS.KinesisVideoWebRTCStorage({
+            region: formValues.region,
+            accessKeyId: formValues.accessKeyId,
+            secretAccessKey: formValues.secretAccessKey,
+            sessionToken: formValues.sessionToken,
+            endpoint: webrtcEndpoint,
+            maxRetries: 0,
+            httpOptions: {
+                timeout: retryIntervalForJoinStorageSession,
+            },
+        });
+
+        // Step 3. Call JoinStorageSession
+        await kinesisVideoClientWebRTCStorageClient
+            .joinStorageSession({
+                channelArn: channelARN,
+            })
+            .promise();
+
+        console.log('[JOIN_STORAGE_SESSION] Finished invoking JoinStorageSession for channel', formValues.channelName);
+    } catch (e) {
+        console.error('[JOIN_STORAGE_SESSION] Encountered error:', e);
+    }
+}

--- a/examples/joinStorageSession.js
+++ b/examples/joinStorageSession.js
@@ -32,7 +32,7 @@ async function joinStorageSessionManually(formValues) {
                 ChannelARN: channelARN,
                 SingleMasterChannelEndpointConfiguration: {
                     Protocols: ['WEBRTC'],
-                    Role: KVSWebRTC.Role.VIEWER,
+                    Role: KVSWebRTC.Role.MASTER,
                 },
             })
             .promise();

--- a/examples/master.js
+++ b/examples/master.js
@@ -151,7 +151,7 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
                 },
             });
         } else {
-            master.streamARN = null;
+            master.storageClient = null;
         }
 
         // Get ICE server configuration

--- a/examples/master.js
+++ b/examples/master.js
@@ -87,7 +87,7 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
             if (mediaServiceMode) {
                 if (!formValues.sendAudio || !formValues.sendVideo) {
                     console.error('[MASTER] Both Send Video and Send Audio checkboxes need to be checked to ingest and store media.');
-                    return;
+                    // return;
                 }
                 protocols.push('WEBRTC');
                 master.streamARN = mediaStorageConfiguration.StreamARN;
@@ -346,7 +346,7 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
         });
 
         master.signalingClient.on('statusResponse', statusResponse => {
-            if (!statusResponse.success) {
+            if (statusResponse.success) {
                 return;
             }
             console.error('[MASTER] Received response from Signaling:', statusResponse);
@@ -371,6 +371,7 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
         master.signalingClient.open();
     } catch (e) {
         console.error('[MASTER] Encountered error starting:', e);
+        onStop();
     }
 }
 

--- a/examples/master.js
+++ b/examples/master.js
@@ -345,8 +345,11 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
             }
         });
 
-        master.signalingClient.on('statusResponse', (statusResponse, senderClientId) => {
-            console.error('[MASTER] Received response from Signaling:', statusResponse, senderClientId || '(no senderClientId provided)');
+        master.signalingClient.on('statusResponse', statusResponse => {
+            if (!statusResponse.success) {
+                return;
+            }
+            console.error('[MASTER] Received response from Signaling:', statusResponse);
 
             if (master.streamARN) {
                 console.error('[MASTER] Encountered a fatal error. Stopping the application.');

--- a/examples/master.js
+++ b/examples/master.js
@@ -150,6 +150,8 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
                     timeout: retryIntervalForJoinStorageSession,
                 },
             });
+        } else {
+            master.streamARN = null;
         }
 
         // Get ICE server configuration

--- a/examples/master.js
+++ b/examples/master.js
@@ -210,11 +210,10 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
             const masterRunId = ++master.runId;
             master.websocketOpened = true;
             console.log('[MASTER] Connected to signaling service');
+            if (formValues.showJSSButton) {
+                $('#join-storage-session-button').removeClass('d-none');
+            }
             if (master.streamARN) {
-                if (formValues.showJSSButton) {
-                    $('#join-storage-session-button').removeClass('d-none');
-                }
-
                 if (formValues.ingestMedia) {
                     await connectToMediaServer(masterRunId);
                 } else {

--- a/examples/master.js
+++ b/examples/master.js
@@ -87,7 +87,7 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
             if (mediaServiceMode) {
                 if (!formValues.sendAudio || !formValues.sendVideo) {
                     console.error('[MASTER] Both Send Video and Send Audio checkboxes need to be checked to ingest and store media.');
-                    // return;
+                    return;
                 }
                 protocols.push('WEBRTC');
                 master.streamARN = mediaStorageConfiguration.StreamARN;

--- a/examples/master.js
+++ b/examples/master.js
@@ -92,6 +92,13 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
                 protocols.push('WEBRTC');
                 master.streamARN = mediaStorageConfiguration.StreamARN;
                 console.log(`[MASTER] Using media ingestion feature. Stream ARN: ${master.streamARN}`);
+
+                $('#master .remote').addClass('d-none');
+                if (formValues.openDataChannel) {
+                    console.warn('[MASTER] DataChannel is not enabled for WebRTC ingestion. Overriding value to false.');
+                    formValues.openDataChannel = false;
+                    $('.datachannel').addClass('d-none');
+                }
             } else {
                 console.log('[MASTER] Not using media ingestion feature.');
                 master.streamARN = null;

--- a/src/SignalingClient.ts
+++ b/src/SignalingClient.ts
@@ -45,16 +45,17 @@ enum ReadyState {
 
 interface WebSocketMessage {
     messageType: MessageType;
-    messagePayload: string;
+    messagePayload?: string;
     senderClientId?: string;
     statusResponse?: StatusResponse;
 }
 
-interface StatusResponse {
+export interface StatusResponse {
     correlationId: 'string';
-    errorType: 'string';
-    statusCode: 'string';
-    description: 'string';
+    success: 'boolean';
+    errorType?: 'string';
+    statusCode?: 'string';
+    description?: 'string';
 }
 
 /**
@@ -287,7 +288,7 @@ export class SignalingClient extends EventEmitter {
                 this.emitOrQueueIceCandidate(parsedMessagePayload, senderClientId);
                 return;
             case MessageType.STATUS_RESPONSE:
-                this.emit('statusResponse', statusResponse, senderClientId);
+                this.emit('statusResponse', statusResponse);
                 return;
         }
     }

--- a/src/SignalingClient.ts
+++ b/src/SignalingClient.ts
@@ -357,7 +357,7 @@ export class SignalingClient extends EventEmitter {
     }
 
     /**
-     * Throws an error if the recipient client id is null and the current role is 'MASTER' as all messages sent as 'MASTER' should have a recipient client id.
+     * Throws an error if the correlationId does not fit the constraints mentioned in {@link https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/kvswebrtc-websocket-apis4.html the documentation}.
      */
     private validateCorrelationId(correlationId?: string): void {
         if (correlationId && !/^[a-zA-Z0-9_.-]{1,256}$/.test(correlationId)) {

--- a/webpack.dist.config.js
+++ b/webpack.dist.config.js
@@ -3,7 +3,7 @@ const TerserPlugin = require('terser-webpack-plugin');
 const merge = require('webpack-merge');
 
 // Define maximum asset size before gzipping
-const MAX_ASSET_SIZE_KB = 23.3;
+const MAX_ASSET_SIZE_KB = 23.6;
 const MAX_ASSET_SIZE_BYTES = MAX_ASSET_SIZE_KB * 1024;
 
 module.exports = merge.smart(require('./webpack.config'), {


### PR DESCRIPTION
## What was changed? 

1. [WebRTC Ingestion] Add a button that lets users manually call JoinStorageSession on the Webpage (to reduce the need to use the AWS CLI). Mainly used for testing purposes. Add a checkbox that decides whether or not that button should be shown (not shown by default).
2. [WebRTC Ingestion] When a peer connection fails to be established with the media ingestion peer, we will initiate a retry faster.
3. Add option to pass in [`correlationId`](https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/kvswebrtc-websocket-apis4.html) into the Signaling messages (and add unit tests for that).
4. Receive [STATUS_RESPONSE](https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/kvswebrtc-websocket-apis-7.html) messages in case any are received. We will emit a `statusResponse` event containing this STATUS_RESPONSE object.
5. [WebRTC ingestion] In this mode, remove the remote-view:

<img width="948" alt="image" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/assets/14988194/a7bfe745-3d93-4ff9-a04a-ea242423d0df">

6. [WebRTC ingestion] In this mode, disable data channel use, overriding the value of the checkbox, if needed.

7. The color of the Stop button was changed to red. This makes it easier to quickly identify. This has been changed for both Master and Viewer.

<img width="360" alt="image" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/assets/14988194/b6586b81-3c59-4d85-92d7-961253caa3dd">


## How was it changed?

1. 
This button is not shown by default. To show it, you need to enable the newly-added checkbox:
<img width="420" alt="image" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/assets/14988194/69aabf12-c324-440a-9541-0fd8b0673979">

After this box is checked, the button will appear next to "Stop Master" after successfully connecting to Signaling.
<img width="568" alt="image" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/assets/14988194/3d7a9633-e014-4823-9119-89223606cb6c">

2.

Previously what happens is that we listen for the PeerConnection state transitioning to failed, and that triggers the retry. From my testing, it takes Google WebRTC around 15 seconds to transition to the FAILED state which is a bit slow. 

We change the original retry initiation from:
* Wait until the Peer Connection state transitions to failed

To:
* Wait until the Peer Connection state transitions to failed, or
* 5 seconds have passed after the SDP answer was sent

3. In the sample, I added correlationId to the SDP_ANSWER for master.
4. In WebRTC ingestion mode, when we receive an error `statusResponse`, we will exit the sample application.

## Testing
* Refresh the page to ensure that the button state is getting saved to local storage
* Pressed the button to confirm that JoinStorageSession is invoked on a Signaling Channel that is configured for ingestion.
* Pressed the button on a Signaling Channel that is not configured for ingestion to confirm the error is handled gracefully.
* Locally remove the "audio+video" requirement and send back an answer without video to confirm that the STATUS_RESPONSE is received for an invalid SDP_ANSWER in WebRTC ingestion mode.
* Connect to a channel without WebRTC ingestion enabled, then one with WebRTC ingestion disabled, and then finally to one that's enabled again to verify the UI elements are all hiding/showing correctly.
* Existing unit tests still pass
* New unit tests pass (100% CC)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
