### PR TITLE
Adjust JoinStorageSession checkbox behavior

### DIFF
--- a/examples/master.js
+++ b/examples/master.js
@@ -74,7 +74,7 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
 
         const protocols = ['WSS', 'HTTPS'];
 
-        if (formValues.region?.toLowerCase() === 'us-west-2' && formValues.ingestMedia) {
+        if (formValues.ingestMedia) {
             console.log('[MASTER] Determining whether to use media ingestion feature.');
             const describeMediaStorageConfigurationResponse = await kinesisVideoClient
                 .describeMediaStorageConfiguration({

--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -126,7 +126,7 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, onR
         const channelARN = describeSignalingChannelResponse.ChannelInfo.ChannelARN;
         console.log('[VIEWER] Channel ARN:', channelARN);
 
-        if (formValues.region?.toLowerCase() === 'us-west-2' && formValues.ingestMedia) {
+        if (formValues.ingestMedia) {
             console.log('[VIEWER] Determining whether this signaling channel is in media ingestion mode.');
             const mediaStorageConfiguration = await kinesisVideoClient
                 .describeMediaStorageConfiguration({


### PR DESCRIPTION
*Description of changes:*
Remove the region check. The checkbox is disabled by default.

### Previous
If the checkbox is checked, the describeMediaStorageConfiguration call will be made in us-west-2.

Now
If the checkbox is checked, the describeMediaStorageConfiguration call will be made.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
