### PR TITLE
Fine-grained ICE candidate filters 

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -526,6 +526,69 @@ function shouldAcceptCandidate(formValues, candidate) {
     }
 }
 
+$('#natTraversalEnabled').on('click', () => {
+    $('#accept-host').prop('checked', true);
+    $('#send-host').prop('checked', true);
+    $('#accept-relay').prop('checked', true);
+    $('#send-relay').prop('checked', true);
+    $('#accept-srflx').prop('checked', true);
+    $('#send-srflx').prop('checked', true);
+    $('#accept-prflx').prop('checked', true);
+    $('#send-prflx').prop('checked', true);
+
+    saveAdvanced();
+});
+
+$('#forceSTUN').on('click', () => {
+    $('#accept-host').prop('checked', false);
+    $('#send-host').prop('checked', false);
+    $('#accept-relay').prop('checked', false);
+    $('#send-relay').prop('checked', false);
+    $('#accept-srflx').prop('checked', true);
+    $('#send-srflx').prop('checked', true);
+    $('#accept-prflx').prop('checked', false);
+    $('#send-prflx').prop('checked', false);
+
+    saveAdvanced();
+});
+
+$('#forceTURN').on('click', () => {
+    $('#accept-host').prop('checked', false);
+    $('#send-host').prop('checked', false);
+    $('#accept-relay').prop('checked', true);
+    $('#send-relay').prop('checked', true);
+    $('#accept-srflx').prop('checked', false);
+    $('#send-srflx').prop('checked', false);
+    $('#accept-prflx').prop('checked', false);
+    $('#send-prflx').prop('checked', false);
+
+    saveAdvanced();
+});
+
+$('#natTraversalDisabled').on('click', () => {
+    $('#accept-host').prop('checked', true);
+    $('#send-host').prop('checked', true);
+    $('#accept-relay').prop('checked', true);
+    $('#send-relay').prop('checked', true);
+    $('#accept-srflx').prop('checked', true);
+    $('#send-srflx').prop('checked', true);
+    $('#accept-prflx').prop('checked', true);
+    $('#send-prflx').prop('checked', true);
+
+    saveAdvanced();
+});
+
+function saveAdvanced() {
+    $('#accept-host').trigger('change');
+    $('#send-host').trigger('change');
+    $('#accept-relay').trigger('change');
+    $('#send-relay').trigger('change');
+    $('#accept-srflx').trigger('change');
+    $('#send-srflx').trigger('change');
+    $('#accept-prflx').trigger('change');
+    $('#send-prflx').trigger('change');
+}
+
 /**
  * Determines whether the ICE Candidate should be sent to the peer.
  * @param formValues Settings used.

--- a/examples/app.js
+++ b/examples/app.js
@@ -492,16 +492,7 @@ fields.forEach(({ field, type, name }) => {
  * @returns true if the candidate should be added to the peerConnection.
  */
 function shouldAcceptCandidate(formValues, candidate) {
-    const words = candidate.candidate.split(' ');
-
-    if (words.length < 7) {
-        console.error('Invalid ice candidate!', candidate);
-        return false;
-    }
-
-    // https://datatracker.ietf.org/doc/html/rfc5245#section-15.1
-    const transport = words[2];
-    const type = words[7];
+    const { transport, type } = extractTransportAndType(candidate);
 
     if (!formValues.acceptUdpCandidates && transport === 'udp') {
         return false;
@@ -596,16 +587,7 @@ function saveAdvanced() {
  * @returns true if the candidate should be sent to the peer.
  */
 function shouldSendIceCandidate(formValues, candidate) {
-    const words = candidate.candidate.split(' ');
-
-    if (words.length < 7) {
-        console.error('Invalid ice candidate!', candidate);
-        return false;
-    }
-
-    // https://datatracker.ietf.org/doc/html/rfc5245#section-15.1
-    const transport = words[2];
-    const type = words[7];
+    const { transport, type } = extractTransportAndType(candidate);
 
     if (!formValues.sendUdpCandidates && transport === 'udp') {
         return false;
@@ -628,6 +610,18 @@ function shouldSendIceCandidate(formValues, candidate) {
             console.warn('ShouldSendICECandidate: Unknown candidate type:', candidate.type);
             return false;
     }
+}
+
+function extractTransportAndType(candidate) {
+    const words = candidate.candidate.split(' ');
+
+    if (words.length < 7) {
+        console.error('Invalid ice candidate!', candidate);
+        return false;
+    }
+
+    // https://datatracker.ietf.org/doc/html/rfc5245#section-15.1
+    return { transport: words[2], type: words[7] };
 }
 
 $('#copy-logs').on('click', async function() {

--- a/examples/index.html
+++ b/examples/index.html
@@ -172,6 +172,66 @@
                 "><sup>&#9432;</sup></span>
                 </div>
             </div>
+
+            <details><summary class="h4">Advanced</summary>
+                <div class="container">
+                    <div class="row">
+                        <div class="col-sm">
+                            <div class="form-check form-check">
+                                <input class="form-check-input" type="checkbox" id="send-relay" checked>
+                                <label for="send-relay" class="form-check-label">Send <code>relay</code> candidates to peer</label>
+                            </div>
+                            <div class="form-check form-check">
+                                <input class="form-check-input" type="checkbox" id="accept-relay" checked>
+                                <label for="accept-relay" class="form-check-label">Accept <code>relay</code> candidates from peer</label>
+                            </div>
+                            <div class="form-check form-check">
+                                <input class="form-check-input" type="checkbox" id="send-srflx" checked>
+                                <label for="send-srflx" class="form-check-label">Send <code>srflx</code> candidates to peer</label>
+                            </div>
+                            <div class="form-check form-check">
+                                <input class="form-check-input" type="checkbox" id="accept-srflx" checked>
+                                <label for="accept-srflx" class="form-check-label">Accept <code>srflx</code> candidates from peer</label>
+                            </div>
+                            <div class="form-check form-check">
+                                <input class="form-check-input" type="checkbox" id="send-host" checked>
+                                <label for="send-host" class="form-check-label">Send <code>host</code> candidates to peer</label>
+                            </div>
+                            <div class="form-check form-check">
+                                <input class="form-check-input" type="checkbox" id="accept-host" checked>
+                                <label for="accept-host" class="form-check-label">Accept <code>host</code> candidates from peer</label>
+                            </div>
+                        </div>
+                        <div class="col-sm">
+                            <div class="form-check form-check">
+                                <input class="form-check-input" type="checkbox" id="send-prflx" checked>
+                                <label for="send-prflx" class="form-check-label">Send <code>prflx</code> candidates to peer</label>
+                            </div>
+                            <div class="form-check form-check">
+                                <input class="form-check-input" type="checkbox" id="accept-prflx" checked>
+                                <label for="accept-prflx" class="form-check-label">Accept <code>prflx</code> candidates from peer</label>
+                            </div>
+                            <div class="form-check form-check">
+                                <input class="form-check-input" type="checkbox" id="send-tcp" checked>
+                                <label for="send-tcp" class="form-check-label">Send <code>tcp</code> candidates to peer</label>
+                            </div>
+                            <div class="form-check form-check">
+                                <input class="form-check-input" type="checkbox" id="accept-tcp" checked>
+                                <label for="accept-tcp" class="form-check-label">Accept <code>tcp</code> candidates from peer</label>
+                            </div>
+                            <div class="form-check form-check">
+                                <input class="form-check-input" type="checkbox" id="send-udp" checked>
+                                <label for="send-udp" class="form-check-label">Send <code>udp</code> candidates to peer</label>
+                            </div>
+                            <div class="form-check form-check">
+                                <input class="form-check-input" type="checkbox" id="accept-udp" checked>
+                                <label for="accept-udp" class="form-check-label">Accept <code>udp</code> candidates from peer</label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </details>
+
             <hr>
             <div>
                 <button id="master-button" type="submit" class="btn btn-primary">Start Master</button>
@@ -291,6 +351,8 @@
                 <div id="webrtc-live-stats"></div>
             </div>
         </div>
+
+
 
         <h3 id="logs-header">Logs</h3>
         <div class="card bg-light mb-3">

--- a/examples/index.html
+++ b/examples/index.html
@@ -174,6 +174,7 @@
             </div>
 
             <details><summary class="h4">Advanced</summary>
+                <p><small>Filter settings for which ICE candidates and sent to and received from the peer.</small></p>
                 <div class="container">
                     <div class="row">
                         <div class="col-sm">

--- a/examples/index.html
+++ b/examples/index.html
@@ -353,8 +353,6 @@
             </div>
         </div>
 
-
-
         <h3 id="logs-header">Logs</h3>
         <div class="card bg-light mb-3">
             <div style="display: flex; justify-content: space-between;">

--- a/examples/master.js
+++ b/examples/master.js
@@ -262,8 +262,12 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
 
                     // When trickle ICE is enabled, send the ICE candidates as they are generated.
                     if (formValues.useTrickleICE) {
-                        printSignalingLog('[MASTER] Sending ICE candidate to client', remoteClientId);
-                        master.signalingClient.sendIceCandidate(candidate, remoteClientId);
+                        if (shouldSendIceCandidate(formValues, candidate)) {
+                            printSignalingLog('[MASTER] Sending ICE candidate to client', remoteClientId);
+                            master.signalingClient.sendIceCandidate(candidate, remoteClientId);
+                        } else {
+                            console.log('[MASTER] Not sending ICE candidate to client', remoteClientId);
+                        }
                     }
                 } else {
                     printSignalingLog('[MASTER] All ICE candidates have been generated for client', remoteClientId);
@@ -311,9 +315,13 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
             printSignalingLog('[MASTER] Received ICE candidate from client', remoteClientId);
             console.debug('[MASTER] ICE candidate:', candidate);
 
-            // Add the ICE candidate received from the client to the peer connection
-            const peerConnection = master.peerConnectionByClientId[remoteClientId];
-            peerConnection.addIceCandidate(candidate);
+            if (shouldAcceptCandidate(formValues, candidate)) {
+                // Add the ICE candidate received from the client to the peer connection
+                const peerConnection = master.peerConnectionByClientId[remoteClientId];
+                peerConnection.addIceCandidate(candidate);
+            } else {
+                console.log('[MASTER] Not adding candidate from peer.');
+            }
         });
 
         master.signalingClient.on('close', () => {

--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -39,7 +39,6 @@ let timeArray = [];
 
 async function startViewer(localView, remoteView, formValues, onStatsReport, onRemoteDataMessage) {
     try {
-        const buttonPressedStart = Date.now();
         console.log('[VIEWER] Client id is:', formValues.clientId);
 
         viewer.localView = localView;
@@ -335,10 +334,6 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, onR
 
         viewer.peerConnection.addEventListener('connectionstatechange', async event => {
             printPeerConnectionStateInfo(event, '[VIEWER]');
-
-            if (event.target.connectionState === 'connected') {
-                console.error(Date.now() - buttonPressedStart, 'ms');
-            }
         });
 
         // As remote tracks are received, add them to the remote view

--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -290,7 +290,11 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, onR
             // Add the ICE candidate received from the MASTER to the peer connection
             console.log('[VIEWER] Received ICE candidate');
             console.debug('ICE candidate', candidate);
-            viewer.peerConnection.addIceCandidate(candidate);
+            if (shouldAddIceCandidate(formValues, candidate)) {
+                viewer.peerConnection.addIceCandidate(candidate);
+            } else {
+                console.log('[VIEWER] Not adding candidate from peer.');
+            }
         });
 
         viewer.signalingClient.on('close', () => {
@@ -309,8 +313,12 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, onR
 
                 // When trickle ICE is enabled, send the ICE candidates as they are generated.
                 if (formValues.useTrickleICE) {
-                    console.log('[VIEWER] Sending ICE candidate');
-                    viewer.signalingClient.sendIceCandidate(candidate);
+                    if (shouldSendIceCandidate(formValues, candidate)) {
+                        console.log('[VIEWER] Sending ICE candidate');
+                        viewer.signalingClient.sendIceCandidate(candidate);
+                    } else {
+                        console.log('[VIEWER] Not sending ICE candidate');
+                    }
                 }
             } else {
                 console.log('[VIEWER] All ICE candidates have been generated');

--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -39,6 +39,7 @@ let timeArray = [];
 
 async function startViewer(localView, remoteView, formValues, onStatsReport, onRemoteDataMessage) {
     try {
+        const buttonPressedStart = Date.now();
         console.log('[VIEWER] Client id is:', formValues.clientId);
 
         viewer.localView = localView;
@@ -290,7 +291,7 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, onR
             // Add the ICE candidate received from the MASTER to the peer connection
             console.log('[VIEWER] Received ICE candidate');
             console.debug('ICE candidate', candidate);
-            if (shouldAddIceCandidate(formValues, candidate)) {
+            if (shouldAcceptCandidate(formValues, candidate)) {
                 viewer.peerConnection.addIceCandidate(candidate);
             } else {
                 console.log('[VIEWER] Not adding candidate from peer.');
@@ -334,6 +335,10 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, onR
 
         viewer.peerConnection.addEventListener('connectionstatechange', async event => {
             printPeerConnectionStateInfo(event, '[VIEWER]');
+
+            if (event.target.connectionState === 'connected') {
+                console.error(Date.now() - buttonPressedStart, 'ms');
+            }
         });
 
         // As remote tracks are received, add them to the remote view


### PR DESCRIPTION
*Description of changes:*
* Add ability to filter which ICE candidates are sent to the peer, and which ones received from the peer that we will consider.

<img width="920" alt="image" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/assets/14988194/12a13051-b8f7-4253-b63b-3f3248bc9571">

* When TURN Only is selected, `host`, `srflx` and `prflx` are disabled.

<img width="918" alt="image" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/assets/14988194/ca49d769-93e2-41a4-a721-d2d2005eac36">

* When STUN Only is selected, `host`, `relay`, and `prflx` are disabled.

<img width="900" alt="image" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/assets/14988194/4038b1a0-5a73-474f-b5c5-4d5aeda234be">

* When STUN/TURN or Disabled is chosen, `host`, `relay`, `prflx`, `srflx` are all enabled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
