### PR TITLE
Support ICE restart and signaling reconnect in samples

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -88,6 +88,10 @@ function getFormValues() {
         secretAccessKey: $('#secretAccessKey').val(),
         sessionToken: $('#sessionToken').val() || null,
         enableDQPmetrics: $('#enableDQPmetrics').is(':checked'),
+        allowIceRestart: $('#allowIceRestart').is(':checked'),
+        allowSignalingReconnect: $('#allowSignalingReconnect').is(':checked')
+
+
     };
 }
 
@@ -410,6 +414,8 @@ const fields = [
     { field: 'forceSTUN', type: 'radio', name: 'natTraversal' },
     { field: 'forceTURN', type: 'radio', name: 'natTraversal' },
     { field: 'natTraversalDisabled', type: 'radio', name: 'natTraversal' },
+    { field: 'allowIceRestart', type: 'checkbox' },
+    { field: 'allowSignalingReconnect', type: 'checkbox' }
 ];
 fields.forEach(({ field, type, name }) => {
     const id = '#' + field;

--- a/examples/index.html
+++ b/examples/index.html
@@ -172,6 +172,27 @@
                 "><sup>&#9432;</sup></span>
                 </div>
             </div>
+            <h4>Amazon KVS failure recovery</h4>
+            <div class="form-group">
+                <div class="form-check form-check-inline">
+                    <input class="form-check-input" type="checkbox" id="allowIceRestart" value="allowIceRestart">
+                    <label for="allowIceRestart" class="form-check-label">Enable ICE restart <small>(Viewer only)</small></label>
+                    <span data-delay="{ &quot;hide&quot;: 1500 }" data-position="auto" tabindex="0" class="text-info ml-1" data-toggle="tooltip" data-html="true" title="
+                    <p>Retries sending offer if ICE transitions to disconnected/failed state. Retry happens a maximum of 3 times if answer is not received within message TTL duration</p>
+                    <a href=&quot;https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/API_SingleMasterConfiguration.html#KinesisVideo-Type-SingleMasterConfiguration-MessageTtlSeconds&quot;>Message TTL information</a>
+                "><sup>&#9432;</sup></span>
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="form-check form-check-inline">
+                    <input class="form-check-input" type="checkbox" id="allowSignalingReconnect" value="allowSignalingReconnect">
+                    <label for="allowSignalingReconnect" class="form-check-label">Allow signaling reconnection in the event of disconnection <small>(Viewer only)</small></label>
+                    <span data-delay="{ &quot;hide&quot;: 1500 }" data-position="auto" tabindex="0" class="text-info ml-1" data-toggle="tooltip" data-html="true" title="
+                    <p>Sends offer again post reconnect in situations of network interruption. Retry happens a maximum of 3 times if answer is not received within message TTL duration</p>
+                    <a href=&quot;https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/API_SingleMasterConfiguration.html#KinesisVideo-Type-SingleMasterConfiguration-MessageTtlSeconds&quot;>Message TTL information</a>
+                "><sup>&#9432;</sup></span>
+                </div>
+            </div>
             <hr>
             <div>
                 <button id="master-button" type="submit" class="btn btn-primary">Start Master</button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,11 +42,6 @@
                 "webpack-merge": "^4.2.2"
             }
         },
-        "eslint": {
-            "name": "eslint-plugin-kvs-webrtc",
-            "version": "1.0.0",
-            "dev": true
-        },
         "node_modules/@ampproject/remapping": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
@@ -9459,8 +9454,9 @@
             }
         },
         "node_modules/eslint-plugin-kvs-webrtc": {
-            "resolved": "eslint",
-            "link": true
+            "version": "1.0.0",
+            "resolved": "file:eslint",
+            "dev": true
         },
         "node_modules/eslint-plugin-prettier": {
             "version": "3.4.1",

--- a/src/SignalingClient.ts
+++ b/src/SignalingClient.ts
@@ -58,8 +58,7 @@ interface WebSocketMessage {
 export class SignalingClient extends EventEmitter {
     private static DEFAULT_CLIENT_ID = 'MASTER';
     private reconnectDelay: number = 2000; // 2 seconds, can be adjusted
-    private reconnected: false;
-    private reconnection: false;
+    private reconnection: boolean;
     private websocket: WebSocket = null;
     private readyState = ReadyState.CLOSED;
     private readonly requestSigner: RequestSigner;
@@ -235,15 +234,12 @@ export class SignalingClient extends EventEmitter {
      */
     private onOpen(): void {
         this.readyState = ReadyState.OPEN;
+        console.log("Reconnection value: ", this.reconnection);
         if(this.reconnection) {
-            this.reconnected = true;
-        }
-        if (!this.reconnected) {
-            console.log("First time connection");
-            this.emit('open');
+            console.log("Successfully opened a new WS");
+            this.emit('reconnect')
         } else {
-            console.log("Reconnection established");
-            this.emit('reconnected');
+            this.emit('open');
         }
     }
 
@@ -356,8 +352,8 @@ export class SignalingClient extends EventEmitter {
 
     private reconnect(attempt = 0): void {
         if (this.readyState === ReadyState.CLOSED) {
-            this.reconnection = true;
             console.log("Attempting to reconnect...");
+            this.reconnection = true;
             this.open();
 
             // If reconnect fails
@@ -372,7 +368,6 @@ export class SignalingClient extends EventEmitter {
                     }
                 } else {
                     console.log("Reconnected");
-                    this.reconnected = true;
                 }
             }, this.reconnectDelay * (attempt + 1)); // increasing delay
         }


### PR DESCRIPTION
*Issue #, if available:*

*What has changed?*
- Included ICE restart and SDP exchange in case of signaling disconnects.

*Why was it changed?*
- To advertise ICE restart in samples and include support for signals application could use to allow SDP negotiation post a signaling close event (network disruption/network change)

*How was it changed?*
- Included a new option in the test page to allow for ICE restart in case a disconnection or ICE agent failure is detected. The ICE restart is tried 3 times with the frequency controlled by messageTtl. In case of failure, we do not retry again. The option is not enabled by default and is controlled via a checkbox in the test page.
- Included a new option in the test page to allow for signaling reconnect in case the WS closes. SDP exchange post signaling reconnect is tried 3 times the frequency of which is controlled by messageTtl. The option is not enabled by default and is controlled via a checkbox in the test page.
- The WS reconnect attempt is configurable by the application. the default is set to 3. If WS reconnection succeeds, the signaling library emits an event for the application to handle offer/answer exchange.

*Testing*
-  Master: C SDK, Viewer: JS SDK on Chrome
    - Modified the C SDK sample to ensure no valid candidate pairs are formed to trigger an ICE restart and succeed post restart
    - Disconnected ethernet and reconnected to ensure ICE restart allows communication to continue
    - Disconnected ethernet to allow connection via WiFi to test out signaling reconnect. ICE restart does not help here since the websocket on the other peer is closed but the SDP offer is supposedly successfully sent.
   
- Master: C SDK, Viewer: JS SDK on Firefox
  - Firefox does not work with reconnection. The issue is on DTLS where, firefox does not seem to work if the remote generates a new fingerprint.
  
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
