### PR TITLE
DQP enhacement and bug fixes

### DIFF
--- a/examples/app.css
+++ b/examples/app.css
@@ -6,6 +6,10 @@
     width: 100%;
 }
 
+#videoPlayerFromMaster {
+    border: 2px solid blue;
+}
+
 #logs-header {
     margin-top: 20px;
 }

--- a/examples/app.css
+++ b/examples/app.css
@@ -6,9 +6,6 @@
     width: 100%;
 }
 
-#videoPlayerFromMaster {
-    border: 2px solid blue;
-}
 
 #logs-header {
     margin-top: 20px;

--- a/examples/index.html
+++ b/examples/index.html
@@ -328,9 +328,7 @@
                 </div>
                 <div class="col">
                     <h5>From Master</h5>
-                    <div class="video-container">
-                        <video id="videoPlayerFromMaster" class="remote-view" autoplay playsinline controls></video>
-                    </div>
+                    <div class="video-container"><video class="remote-view" autoplay playsinline controls></video></div>
                 </div>
             </div>
             <div class="row datachannel">

--- a/examples/index.html
+++ b/examples/index.html
@@ -328,7 +328,9 @@
                 </div>
                 <div class="col">
                     <h5>From Master</h5>
-                    <div class="video-container"><video class="remote-view" autoplay playsinline controls></video></div>
+                    <div class="video-container">
+                        <video id="videoPlayerFromMaster" class="remote-view" autoplay playsinline controls></video>
+                    </div>
                 </div>
             </div>
             <div class="row datachannel">

--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -250,10 +250,10 @@ let dataChannelLatencyCalcMessage = {
     'lastMessageFromViewerTs': ''
 }
 
-async function startViewer(localView, remoteView, formValues, onStatsReport, onRemoteDataMessage) {
+async function startViewer(localView, remoteView, formValues, onStatsReport, remoteMessage) {
     try {
         console.log('[VIEWER] Client id is:', formValues.clientId);
-        viewerButtonPressed = Date.now();
+        viewerButtonPressed = new Date();
 
         if (formValues.enableProfileTimeline) {
             setTimeout(profilingCalculations, profilingTestLength * 1000);
@@ -1027,8 +1027,7 @@ function calcStats(stats, clientId) {
                     '<tr><td>Time from viewer button click to signaling setup: </td><td>' + signalingSetUpTime + ' ms</td></tr>' +
                     '<tr><td>Time to set up viewer media view: </td><td>' + timeToSetUpViewerMedia + ' ms</td></tr>' +
                     '<tr><td>Time from offer to first decoded frame: </td><td>' + timeToFirstFrameFromOffer + ' ms</td></tr>' +
-                    '<tr><td>Time from viewer button click to first decoded frame: </td><td>' + timeToFirstFrameFromViewerStart + ' ms</td></tr>' +
-                    '<tr><td>Time to decoded stream (as seen from inbound stats): </td><td>' + (statStartTime - viewerButtonPressed.getTime()) + ' ms</td></tr></table>';
+                    '<tr><td>Time from viewer button click to first decoded frame: </td><td>' + timeToFirstFrameFromViewerStart + ' ms</td></tr>';
                 testAvgRTT = avgRtt;
                 testAvgFPS = avgFramerate;
                 testAvgDropPer = avgDropPercent;
@@ -1053,10 +1052,9 @@ function calcStats(stats, clientId) {
                     '<tr><td>Selected remote candidate: </td><td>' + remoteCandidateConnectionString + '</td></tr>' +
                     '<tr><td>Selected local candidate: </td><td>' + localCandidateConnectionString + '</td></tr>' +
                     '<tr><td>Time from viewer button click to signaling setup: </td><td>' + signalingSetUpTime + ' ms</td></tr>' +
-                    '<tr><td>Time to set up viewer media view: </td><td>' + timeToSetUpViewerMedia + ' ms</td></tr>' +
+                    '<tr><td>Time set up viewer media view: </td><td>' + timeToSetUpViewerMedia + ' ms</td></tr>' +
                     '<tr><td>Time from offer to first decoded frame: </td><td>' + timeToFirstFrameFromOffer + ' ms</td></tr>' +
-                    '<tr><td>Time from viewer button click to first decoded frame: </td><td>' + timeToFirstFrameFromViewerStart + ' ms</td></tr>' +
-                    '<tr><td>Time to decoded stream (as seen from inbound stats): </td><td>' + (statStartTime - viewerButtonPressed.getTime()) + ' ms</td></tr>' +
+                    '<tr><td>Time from viewer button click to first decoded frame (without viewer media screen set up): </td><td>' + (timeToFirstFrameFromViewerStart - timeToSetUpViewerMedia) + ' ms</td></tr>' +
                     '<tr><td>Avg RTT: </td><td>' + testAvgRTT.toFixed(3) + ' sec</td></tr>' +
                     '<tr><td>Video Resolution: </td><td>' + videoWidth + ' x ' + videoHeight + '</td></tr>' +
                     '<tr><td>Avg Video bitrate: </td><td>' + testAvgVbitrate.toFixed(1) + ' kbps</td></tr>' +


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Time to decoded frame: The calculation methodology for  was incorrect. The way it was being measured would not give an accurate representation of the actual time taken to decode the first received frame. The application current uses `inbound-stats` to measure this value and these stats are polled every 1 second, which means, there is a possibility that the time calculated is 1 second more than what it actually took to decode the first frame. This PR fixes it by listening in on the `[onloadeddata](https://www.w3schools.com/jsref/event_onloadeddata.asp)` event tied to the master video element which is invoked when the first frame is received. 

- Time to P2P: The calculation for this is from the start of viewer button click to when the first `track` event is received. This is not a real measure of P2P, or atleast it is not clear what the intent of this is. This PR gets rid of this and instead adds 3 more metrics: Time taken for signaling setup, Time to set up viewer video view element and time taken from offer to first frame decode. 

- Time from viewer button click to first frame decode: Added a new measure to indicate the total time taken to get the remote view on the screen. 

- Selected candidate pair: Added details on the selected local and remote candidate which will show up after 10 seconds. 

- Modified time unit to ms display for latency measurements to be accurate. 
Before this change:

Initial view: 
<img width="488" alt="Screenshot 2023-12-14 at 3 34 52 PM" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/assets/22107309/7fe6404c-93e6-45dc-8ebb-0aa1560250a2">


After 120 seconds:
<img width="490" alt="Screenshot 2023-12-14 at 3 37 40 PM" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/assets/22107309/7fdfcb3b-6c13-4f17-9987-848f530a11c2">


After this PR:

Initial view:
<img width="472" alt="Screenshot 2023-12-14 at 3 41 17 PM" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/assets/22107309/87fd5c2b-0c2b-4637-b5d9-4fff53b81b17">

After 10 seconds:

<img width="469" alt="Screenshot 2023-12-14 at 3 41 29 PM" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/assets/22107309/b26b0fe7-2669-4948-ac3f-8e437810ff77">

Note from the screenshot how there is a 931ms difference between `Time to decoded stream (as seen from inbound stats)` and `Time from viewer button click to first decoded frame`.

To do:

- Debug why prflx candidate information is empty.
- Firefox doesnt display local candidate details.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
