### PR TITLE
Fix readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,20 @@
-# Amazon Kinesis Video Streams WebRTC SDK for JavaScript
+<h1 align="center">
+    Amazon Kinesis Video Streams WebRTC SDK for JavaScript
+    <br />
+</h1>
 
+<div align="center"> 
+    
 [![NPM version](https://img.shields.io/npm/v/amazon-kinesis-video-streams-webrtc.svg?style=flat-square)](https://www.npmjs.com/package/amazon-kinesis-video-streams-webrtc)
 [![NPM downloads](https://img.shields.io/npm/dm/amazon-kinesis-video-streams-webrtc.svg?style=flat-square)](https://www.npmjs.com/package/amazon-kinesis-video-streams-webrtc)
 [![NPM version](https://img.shields.io/npm/l/amazon-kinesis-video-streams-webrtc?style=flat-square)](https://www.npmjs.com/package/amazon-kinesis-video-streams-webrtc)
 
 
-[![Build Status](https://img.shields.io/travis/com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/master?style=flat-square)](https://travis-ci.com/github/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js)
-[![Build Status](https://img.shields.io/bundlephobia/minzip/amazon-kinesis-video-streams-webrtc?style=flat-square)]()
-[![Coverage Status](https://codecov.io/gh/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/branch/master/graph/badge.svg)](https://codecov.io/gh/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js)
-[![Known Vulnerabilities](https://img.shields.io/snyk/vulnerabilities/npm/amazon-kinesis-video-streams-webrtc?style=flat-square)](https://snyk.io/test/github/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js?targetFile=package.json)
+[![Build Status](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/actions/workflows/ci.yml/badge.svg)](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/actions/workflows/ci.yml/badge.svg)
+[![Minzipped Size](https://img.shields.io/bundlephobia/minzip/amazon-kinesis-video-streams-webrtc?style=flat-square)]()
+[![Known Vulnerabilities](https://snyk.io/test/github/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/badge.svg)](https://snyk.io/test/github/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js)
 
+</div>
 
 ## What is Amazon Kinesis Video Streams with WebRTC?
 


### PR DESCRIPTION
*Description of changes:*
* Adjust badges in the readme.

Before:

<img width="929" alt="image" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/assets/14988194/e686e5f3-79ff-4d17-be28-5ec387e373a1">

After:

<img width="1119" alt="image" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/assets/14988194/c7021ab4-22f2-4176-af71-345584f38d8e">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
