### PR TITLE
Fix typo in WebRTC Test Page

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -191,7 +191,7 @@
             </div>
 
             <details><summary class="h4">Advanced</summary>
-                <p><small>Filter settings for which ICE candidates and sent to and received from the peer.</small></p>
+                <p><small>Filter settings for which ICE candidates are sent to and received from the peer.</small></p>
                 <div class="container">
                     <div class="row">
                         <div class="col-sm">


### PR DESCRIPTION
> Filter settings for which ICE candidates `and` sent to and received from the peer.

and -> are

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
