### PR TITLE
global.WebSocket -> WebSocket

### DIFF
--- a/src/SignalingClient.ts
+++ b/src/SignalingClient.ts
@@ -148,7 +148,7 @@ export class SignalingClient extends EventEmitter {
         }
 
         /* istanbul ignore next */
-        this.websocket = new (global.WebSocket || require('ws'))(signedURL);
+        this.websocket = new (WebSocket || require('ws'))(signedURL);
 
         this.websocket.addEventListener('open', this.onOpen);
         this.websocket.addEventListener('message', this.onMessage);


### PR DESCRIPTION
*Issue #, if available:*
#306

*Description of changes:*
* Depending on specific environment, `global` object may not exist. We leave it up to the interpreter to resolve the WebSocket reference in the scope chain.

*Testing*
* Run unit tests, they pass.
* This local change (STUN/TURN selected) <--> Live JS page
* This local change (TURN only selected) <--> Live JS page
* This local change (STUN/TURN selected) <--> C SDK
* This local change (TURN only selected) <--> C SDK

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
