### PR TITLE
Sample: Master Cleanup

### DIFF
--- a/examples/channelHelper.js
+++ b/examples/channelHelper.js
@@ -1,0 +1,184 @@
+class ChannelHelper {
+    static IngestionMode = {
+        // P2P (no ingestion)
+        OFF: 0,
+
+        // Do not call DescribeMediaStorageConfiguration API, assume channel
+        // is already configured for ingestion.
+        ON: 1,
+
+        // Call DescribeMediaStorageConfiguration API to dynamically determine
+        // operating mode.
+        DETERMINE_THROUGH_DESCRIBE: 2,
+    };
+
+    constructor(channelName, clientArgs, endpoint, role, ingestionMode, loggingPrefix) {
+        this._channelName = channelName;
+        this._clientArgs = clientArgs;
+        this._role = role;
+        this._endpoint = endpoint;
+        this._ingestionMode = ingestionMode;
+        this._loggingPrefix = loggingPrefix;
+    }
+
+    async init() {
+        await this._initializeClients();
+    }
+
+    close() {
+        this._signalingClient.close();
+    }
+
+    getChannelArn = () => {
+        return this._channelArn;
+    };
+
+    getKinesisVideoClient = () => {
+        return this._kinesisVideoClient;
+    };
+
+    getSignalingClient = () => {
+        return this._signalingClient;
+    };
+
+    isIngestionEnabled = () => {
+        return this._ingestionMode === this._ingestionMode.ON;
+    };
+
+    getWebRTCStorageClient = () => {
+        return this._webrtcStorageClient;
+    };
+
+    fetchTurnServers = async () => {
+        return (await this._signalingChannelsClient.getIceServerConfig({ ChannelARN: this._channelArn }).promise()).IceServerList.flatMap(iceServer => ({
+            urls: iceServer.Uris,
+            username: iceServer.Username,
+            credential: iceServer.Password,
+        }));
+    };
+
+    getSignalingConnectionLastStarted = () => {
+        return this._signalingConnectionStarted;
+    };
+
+    // Creates the following clients and saves them as member variables.
+    //   AWS.KinesisVideo                  --> this._kinesisVideoClient
+    //   AWS.KinesisVideoSignalingChannels --> this._signalingChannelsClient
+    //   KVSWebRTC.SignalingClient         --> this._signalingClient
+    async _initializeClients() {
+        // Kinesis Video Client
+        // Used to invoke APIs under https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/API_Operations_Amazon_Kinesis_Video_Streams.html
+        this._kinesisVideoClient = new AWS.KinesisVideo({
+            ...this._clientArgs,
+            endpoint: this._endpoint,
+            correctClockSkew: true,
+        });
+
+        const describeSignalingChannelResponse = await this._kinesisVideoClient
+            .describeSignalingChannel({
+                ChannelName: this._channelName,
+            })
+            .promise();
+
+        this._channelArn = describeSignalingChannelResponse.ChannelInfo.ChannelARN;
+        console.debug(this._loggingPrefix, 'Channel ARN:', this._channelArn);
+
+        if (this._ingestionMode === ChannelHelper.IngestionMode.DETERMINE_THROUGH_DESCRIBE) {
+            const describeMediaStorageConfigurationResponse = await this._kinesisVideoClient
+                .describeMediaStorageConfiguration({
+                    ChannelARN: master.channelARN,
+                })
+                .promise();
+            const mediaStorageConfiguration = describeMediaStorageConfigurationResponse.MediaStorageConfiguration;
+
+            if (mediaStorageConfiguration.Status === 'ENABLED' || mediaStorageConfiguration.StreamARN !== null) {
+                this._ingestionMode = ChannelHelper.IngestionMode.ON;
+            } else {
+                this._ingestionMode = ChannelHelper.IngestionMode.OFF;
+            }
+        }
+
+        const protocols = ['HTTPS', 'WSS'];
+        if (this._ingestionMode === ChannelHelper.IngestionMode.ON) {
+            protocols.push('WEBRTC');
+        }
+
+        // Result: { HTTPS: "https://...", WSS: "wss://..." }
+        // Will include WEBRTC if in ingestionMode
+        this._endpoints = await this._getSignalingChannelEndpoints(this._kinesisVideoClient, this._channelArn, this._role, protocols);
+
+        // Kinesis Video Signaling Channels Client
+        // Used to invoke APIs under https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/API_Operations_Amazon_Kinesis_Video_Signaling_Channels.html
+        this._signalingChannelsClient = new AWS.KinesisVideoSignalingChannels({
+            ...this._clientArgs,
+            endpoint: this._endpoints['HTTPS'],
+            correctClockSkew: true,
+        });
+
+        // Kinesis Video Signaling Client
+        // Used to invoke APIs under https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/kvswebrtc-websocket-apis.html
+        this._signalingClient = new KVSWebRTC.SignalingClient({
+            channelARN: this._channelArn,
+            channelEndpoint: this._endpoints['WSS'],
+            role: this._role,
+            region: this._clientArgs.region,
+            credentials: {
+                accessKeyId: this._clientArgs.accessKeyId,
+                secretAccessKey: this._clientArgs.secretAccessKey,
+                sessionToken: this._clientArgs.sessionToken,
+            },
+            requestSigner: {
+                // Inside the function, `this` refers to the function itself,
+                // not the surrounding object where _clientArgs is defined.
+                // Arrow function preserves the lexical scope.
+                getSignedURL: async (signalingEndpoint, queryParams, date) => {
+                    const signer = new KVSWebRTC.SigV4RequestSigner(this._clientArgs.region, {
+                        accessKeyId: this._clientArgs.accessKeyId,
+                        secretAccessKey: this._clientArgs.secretAccessKey,
+                        sessionToken: this._clientArgs.sessionToken,
+                    });
+
+                    const signingStart = new Date();
+                    console.debug(this._loggingPrefix, 'Signing the url started at', signingStart);
+                    const retVal = await signer.getSignedURL(signalingEndpoint, queryParams, date);
+                    const signingEnd = new Date();
+                    console.debug(this._loggingPrefix, 'Signing the url ended at', signingEnd);
+                    console.log(this._loggingPrefix, 'Time to sign the request:', signingEnd.getTime() - signingStart.getTime(), 'ms');
+                    this._signalingConnectionStarted = new Date();
+                    console.log(this._loggingPrefix, 'Connecting to KVS Signaling...');
+                    console.debug(
+                        this._loggingPrefix,
+                        `ConnectAs${this._role.charAt(0).toUpperCase()}${this._role.slice(1).toLowerCase()} started at ${this._signalingConnectionStarted}`,
+                    );
+                    return retVal;
+                },
+            },
+            systemClockOffset: this._kinesisVideoClient.config.systemClockOffset,
+        });
+
+        if (this._ingestionMode.ON) {
+            this._webrtcStorageClient = new AWS.KinesisVideoWebRTCStorage({
+                ...this._clientArgs,
+                endpoint: this._endpoints['WEBRTC'],
+            });
+        }
+    }
+
+    async _getSignalingChannelEndpoints(kinesisVideoClient, arn, role, protocols) {
+        const getSignalingChannelEndpointResponse = await kinesisVideoClient
+            .getSignalingChannelEndpoint({
+                ChannelARN: arn,
+                SingleMasterChannelEndpointConfiguration: {
+                    Protocols: protocols,
+                    Role: role,
+                },
+            })
+            .promise();
+        const endpointsByProtocol = getSignalingChannelEndpointResponse.ResourceEndpointList.reduce((endpoints, endpoint) => {
+            endpoints[endpoint.Protocol] = endpoint.ResourceEndpoint;
+            return endpoints;
+        }, {});
+        console.debug(this._loggingPrefix, 'Endpoints:', endpointsByProtocol);
+        return endpointsByProtocol;
+    }
+}

--- a/examples/channelHelper.js
+++ b/examples/channelHelper.js
@@ -197,6 +197,8 @@ class ChannelHelper {
     // Returns an object containing the protocols as keys and the
     // returned endpoint as values: { HTTPS: "https://...", WSS: "wss://..." }
     async _getSignalingChannelEndpoints(kinesisVideoClient, arn, role, protocols) {
+        // This API will throw an error if WEBRTC protocol is specified but
+        // the channel is not configured for ingestion
         const getSignalingChannelEndpointResponse = await kinesisVideoClient
             .getSignalingChannelEndpoint({
                 ChannelARN: arn,

--- a/examples/index.html
+++ b/examples/index.html
@@ -410,6 +410,7 @@
 <div id="test"></div>
 
 <script src="../kvs-webrtc.js"></script>
+<script src="./channelHelper.js"></script>
 <script src="./master.js"></script>
 <script src="./viewer.js"></script>
 <script src="./createSignalingChannel.js"></script>

--- a/examples/master.js
+++ b/examples/master.js
@@ -137,7 +137,7 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
             // $('#master .local-view').addClass('d-none');
         }
 
-        registerMasterSignalingClientCallbacks(master.channelHelper.getSignalingClient(), formValues, configuration);
+        registerMasterSignalingClientCallbacks(master.channelHelper.getSignalingClient(), formValues, configuration, onStatsReport, onRemoteDataMessage);
         console.log('[MASTER] Starting master connection');
         master.channelHelper.getSignalingClient().open();
     } catch (e) {
@@ -146,7 +146,7 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
     }
 }
 
-registerMasterSignalingClientCallbacks = (signalingClient, formValues, configuration) => {
+registerMasterSignalingClientCallbacks = (signalingClient, formValues, configuration, onStatsReport, onRemoteDataMessage) => {
     signalingClient.on('open', async () => {
         const masterRunId = ++master.runId;
         master.websocketOpened = true;

--- a/examples/master.js
+++ b/examples/master.js
@@ -51,10 +51,8 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
 
         // Determine the media ingestion mode
         let ingestionMode = ChannelHelper.IngestionMode.OFF;
-        if (formValues.ingestMedia) {
+        if (formValues.ingestMedia || formValues.showJSSButton) {
             ingestionMode = ChannelHelper.IngestionMode.DETERMINE_THROUGH_DESCRIBE;
-        } else if (formValues.showJSSButton) {
-            ingestionMode = ChannelHelper.IngestionMode.ON;
         }
 
         master.channelHelper = new ChannelHelper(

--- a/examples/master.js
+++ b/examples/master.js
@@ -53,6 +53,8 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
         let ingestionMode = ChannelHelper.IngestionMode.OFF;
         if (formValues.ingestMedia) {
             ingestionMode = ChannelHelper.IngestionMode.DETERMINE_THROUGH_DESCRIBE;
+        } else if (formValues.showJSSButton) {
+            ingestionMode = ChannelHelper.IngestionMode.ON;
         }
 
         master.channelHelper = new ChannelHelper(
@@ -192,7 +194,10 @@ registerMasterSignalingClientCallbacks = (signalingClient, formValues, configura
             printPeerConnectionStateInfo(event, '[MASTER]', remoteClientId);
 
             if (master.channelHelper.isIngestionEnabled() && event.target.connectionState === 'connected') {
-                console.log('[MASTER] Successfully joined the storage session. Media is being recorded to', master.channelHelper.getStreamArn());
+                console.log(
+                    '[MASTER] Successfully joined the storage session. Media is being recorded to',
+                    master.channelHelper.getStreamArn() ?? 'Kinesis Video Streams',
+                );
             }
         });
 

--- a/examples/master.js
+++ b/examples/master.js
@@ -345,7 +345,7 @@ function stopMaster() {
         console.log('[MASTER] Stopping master connection');
         master.sdpOfferReceived = true;
 
-        master.channelHelper.getSignalingClient().close();
+        master.channelHelper.getSignalingClient()?.close();
 
         Object.keys(master.peerConnectionByClientId).forEach(clientId => {
             master.peerConnectionByClientId[clientId].close();

--- a/examples/master.js
+++ b/examples/master.js
@@ -328,7 +328,7 @@ function onPeerConnectionFailed(printLostConnectionLog = true) {
         master.sdpOfferReceived = false;
         if (!master.websocketOpened) {
             console.log('[MASTER] Websocket is closed. Reopening...');
-            master.signalingClient.open();
+            master.channelHelper.getSignalingClient().open();
         } else {
             connectToMediaServer(++master.runId);
         }
@@ -340,7 +340,7 @@ function stopMaster() {
         console.log('[MASTER] Stopping master connection');
         master.sdpOfferReceived = true;
 
-        master.channelHelper.close();
+        master.channelHelper.getSignalingClient().close();
 
         Object.keys(master.peerConnectionByClientId).forEach(clientId => {
             master.peerConnectionByClientId[clientId].close();
@@ -459,7 +459,7 @@ async function connectToMediaServer(masterRunId) {
     } else if (!master.websocketOpened && !master.sdpOfferReceived) {
         // TODO: ideally, we send a ping message. But, that's unavailable in browsers.
         console.log('[MASTER] Websocket is closed. Reopening...');
-        master.signalingClient.open();
+        master.channelHelper.getSignalingClient().open();
     }
 }
 


### PR DESCRIPTION
## Description of changes
* Move common code that can be shared between master and viewer to a separate class w/ appropriate public interfaces. This makes the AWS SDK calls abstracted out and make the sample more readable and easy to modify.

## Testing

Manual testing:
* Local changes (master, chrome) --> Deployed JS Webpage (viewer, chrome)
* Local changes (master, firefox) --> Deployed JS Webpage (viewer, chrome)
* Local changes (master, safari) --> Deployed JS Webpage (viewer, chrome)
* Local changes (master, chrome) --> Deployed JS Webpage (viewer, chrome) sending/receiving datachannel messages on both sides
* Local changes (master, chrome) --> iOS (viewer)
* Local changes (master, chrome) --> Android (viewer)
* Local changes (master, chrome) --> WebRTC ingestion [success case]
* Local changes (master, chrome) --> WebRTC ingestion [failure case, channel not configured for ingestion, verify that application exits]
* Local changes (master, chrome) --> WebRTC ingestion [failure case, verify the 5 connections within 10 minutes]
* Local changes (master, firefox) --> WebRTC ingestion [failure case, verify that statusResponse is still printed and application exits]

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
