### PR TITLE
Move endpoint to advanced

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -25,16 +25,12 @@
     <div class="row loader"></div>
     <div id="main" class="d-none">
         <form id="form" onsubmit="return false">
-            <h4>KVS Endpoint</h4>
+            <h4>AWS Region</h4>
             <div class="form-group has-validation" style="position: relative;">
-                <label for="region">Region</label>
+                <label for="region">Region your signaling channel is located</label>
                 <input type="text" class="form-control valid" id="region" placeholder="Region" value="us-west-2" autocomplete="off" required>
                 <datalist id="regionList"></datalist>
                 <div id="region-invalid-feedback" class="invalid-feedback"></div>
-            </div>
-            <div class="form-group">
-                <label for="endpoint">Endpoint <small>(optional)</small></label>
-                <input type="text" class="form-control" id="endpoint" placeholder="Endpoint">
             </div>
             <h4>AWS Credentials</h4>
             <div class="form-group">
@@ -192,7 +188,7 @@
 
             <details><summary class="h4">Advanced</summary>
                 <p><small>Filter settings for which ICE candidates are sent to and received from the peer.</small></p>
-                <div class="container">
+                <div class="container mb-3">
                     <div class="row">
                         <div class="col-sm">
                             <div class="form-check form-check">
@@ -247,6 +243,11 @@
                             </div>
                         </div>
                     </div>
+                </div>
+
+                <div class="form-group">
+                    <label for="endpoint"><small>Endpoint override (optional)</small></label>
+                    <input type="text" class="form-control" id="endpoint" placeholder="Endpoint">
                 </div>
             </details>
 


### PR DESCRIPTION
*Description of changes:*
* Move the `Endpoint override` to the Advanced section of the sample page. Since this feature is very rarely used, it doesn't make much sense to have it as the first thing we see.

### Before:
<img width="1160" alt="image" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/assets/14988194/b44e4993-2ccc-4364-959e-d7d75a1562aa">
<img width="1160" alt="image" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/assets/14988194/6e4c0644-15a3-4748-8c2c-d02529e0ee4c">


### After:

<img width="1160" alt="image" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/assets/14988194/e95285a4-92b9-44ea-b7ac-3ef5ae6db65c">
<img width="1160" alt="image" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/assets/14988194/e827a587-11ca-4f58-994b-f9e2f171eb0c">




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
