### PR TITLE
Fix webpack size limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - master
       - develop
+      - dependabot/npm_and_yarn/develop/tslib-2.8.1
 
 jobs:
   nodejs-ubuntu-build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
     branches:
       - master
       - develop
-      - dependabot/npm_and_yarn/develop/tslib-2.8.1
 
 jobs:
   nodejs-ubuntu-build:

--- a/webpack.dist.config.js
+++ b/webpack.dist.config.js
@@ -3,8 +3,8 @@ const TerserPlugin = require('terser-webpack-plugin');
 const { merge } = require('webpack-merge');
 
 // Define maximum asset size before gzipping
-const MAX_ASSET_SIZE_KB = 23.6;
-const MAX_ASSET_SIZE_BYTES = MAX_ASSET_SIZE_KB * 1024;
+const MAX_ASSET_SIZE_KIB = 30;
+const MAX_ASSET_SIZE_BYTES = MAX_ASSET_SIZE_KIB * 1024;
 
 module.exports = merge(require('./webpack.config'), {
     mode: 'production',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Increase webpack's max asset and entry point sizes to allow for TSlib version bump.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
