### PR TITLE
Bump eslint-plugin-prettier to v5.2.1, apply new formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
     branches:
       - master
       - develop
-      - dependabot/npm_and_yarn/develop/prettier-3.4.2
 
 jobs:
   nodejs-ubuntu-build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - master
       - develop
+      - dependabot/npm_and_yarn/develop/prettier-3.4.2
 
 jobs:
   nodejs-ubuntu-build:

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
                 "eslint": "^9.16.0",
                 "eslint-config-prettier": "^6.3.0",
                 "eslint-plugin-kvs-webrtc": "file:eslint",
-                "eslint-plugin-prettier": "^3.1.0",
+                "eslint-plugin-prettier": "^5.2.1",
                 "fork-ts-checker-webpack-plugin": "^9.0.2",
                 "jest": "^29.5.0",
                 "jest-environment-jsdom": "^29.5.0",
@@ -4716,6 +4716,19 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
             "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
         },
+        "node_modules/@pkgr/core": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
+            "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/unts"
+            }
+        },
         "node_modules/@react-native-community/cli": {
             "version": "10.2.2",
             "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-10.2.2.tgz",
@@ -9266,21 +9279,31 @@
             "link": true
         },
         "node_modules/eslint-plugin-prettier": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz",
-            "integrity": "sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.1.tgz",
+            "integrity": "sha512-gH3iR3g4JfF+yYPaJYkN7jEl9QbweL/YfkoRlNnuIEHEz1vHVlCmWOS+eGGiRuzHQXdJFCOTxRgvju9b8VUmrw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "prettier-linter-helpers": "^1.0.0"
+                "prettier-linter-helpers": "^1.0.0",
+                "synckit": "^0.9.1"
             },
             "engines": {
-                "node": ">=6.0.0"
+                "node": "^14.18.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint-plugin-prettier"
             },
             "peerDependencies": {
-                "eslint": ">=5.0.0",
-                "prettier": ">=1.13.0"
+                "@types/eslint": ">=8.0.0",
+                "eslint": ">=8.0.0",
+                "eslint-config-prettier": "*",
+                "prettier": ">=3.0.0"
             },
             "peerDependenciesMeta": {
+                "@types/eslint": {
+                    "optional": true
+                },
                 "eslint-config-prettier": {
                     "optional": true
                 }
@@ -18941,6 +18964,30 @@
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+        },
+        "node_modules/synckit": {
+            "version": "0.9.2",
+            "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.2.tgz",
+            "integrity": "sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@pkgr/core": "^0.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": "^14.18.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/unts"
+            }
+        },
+        "node_modules/synckit/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
         },
         "node_modules/tapable": {
             "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "eslint": "^9.16.0",
         "eslint-config-prettier": "^6.3.0",
         "eslint-plugin-kvs-webrtc": "file:eslint",
-        "eslint-plugin-prettier": "^3.1.0",
+        "eslint-plugin-prettier": "^5.2.1",
         "fork-ts-checker-webpack-plugin": "^9.0.2",
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",

--- a/src/SigV4RequestSigner.spec.ts
+++ b/src/SigV4RequestSigner.spec.ts
@@ -43,7 +43,7 @@ describe('SigV4RequestSigner', () => {
                 accessKeyId: null,
                 secretAccessKey: null,
                 getPromise(): Promise<void> {
-                    return new Promise<void>(resolve => {
+                    return new Promise<void>((resolve) => {
                         credentials.accessKeyId = 'AKIA4F7WJQR7FMMWMNXI';
                         credentials.secretAccessKey = 'FakeSecretKey';
                         credentials.sessionToken = 'FakeSessionToken';

--- a/src/SigV4RequestSigner.ts
+++ b/src/SigV4RequestSigner.ts
@@ -138,7 +138,7 @@ export class SigV4RequestSigner implements RequestSigner {
      */
     private static createHeadersString(headers: Headers): string {
         return Object.keys(headers)
-            .map(header => `${header}:${headers[header]}\n`)
+            .map((header) => `${header}:${headers[header]}\n`)
             .join();
     }
 
@@ -148,7 +148,7 @@ export class SigV4RequestSigner implements RequestSigner {
     private static createQueryString(queryParams: QueryParams): string {
         return Object.keys(queryParams)
             .sort()
-            .map(key => `${key}=${encodeURIComponent(queryParams[key])}`)
+            .map((key) => `${key}=${encodeURIComponent(queryParams[key])}`)
             .join('&');
     }
 
@@ -209,7 +209,7 @@ export class SigV4RequestSigner implements RequestSigner {
 
     private static toHex(buffer: ArrayBuffer): string {
         return Array.from(new Uint8Array(buffer))
-            .map(b => b.toString(16).padStart(2, '0'))
+            .map((b) => b.toString(16).padStart(2, '0'))
             .join('');
     }
 }

--- a/src/SignalingClient.spec.ts
+++ b/src/SignalingClient.spec.ts
@@ -117,7 +117,7 @@ describe('SignalingClient', () => {
 
     beforeEach(() => {
         mockDateClass(mockDate);
-        signer = jest.fn().mockImplementation(endpoint => new Promise(resolve => resolve(endpoint)));
+        signer = jest.fn().mockImplementation((endpoint) => new Promise((resolve) => resolve(endpoint)));
         config = {
             role: Role.VIEWER,
             clientId: CLIENT_ID,
@@ -185,7 +185,7 @@ describe('SignalingClient', () => {
     });
 
     describe('open', () => {
-        it('should open a connection to the signaling server as the viewer', done => {
+        it('should open a connection to the signaling server as the viewer', (done) => {
             const client = new SignalingClient(config as SignalingClientConfig);
             client.on('open', () => {
                 expect(signer).toBeCalledWith(
@@ -201,7 +201,7 @@ describe('SignalingClient', () => {
             client.open();
         });
 
-        it('should open a connection to the signaling server as the master', done => {
+        it('should open a connection to the signaling server as the master', (done) => {
             config.role = Role.MASTER;
             delete config.clientId;
             const client = new SignalingClient(config as SignalingClientConfig);
@@ -218,7 +218,7 @@ describe('SignalingClient', () => {
             client.open();
         });
 
-        it('should open a connection to the signaling server with clock skew adjusted date', done => {
+        it('should open a connection to the signaling server with clock skew adjusted date', (done) => {
             config.systemClockOffset = 1000000;
             const client = new SignalingClient(config as SignalingClientConfig);
             client.on('open', () => {
@@ -236,14 +236,14 @@ describe('SignalingClient', () => {
         });
 
         it('should not open a connection to the signaling server if it is closed while opening', async () => {
-            config.requestSigner.getSignedURL = jest.fn().mockImplementation(endpoint => new Promise(resolve => setTimeout(() => resolve(endpoint), 5)));
+            config.requestSigner.getSignedURL = jest.fn().mockImplementation((endpoint) => new Promise((resolve) => setTimeout(() => resolve(endpoint), 5)));
             const client = new SignalingClient(config as SignalingClientConfig);
             client.on('open', () => {
                 expect('Should not have fired an event').toBeFalsy();
             });
             client.open();
             client.close();
-            return new Promise(resolve => setTimeout(resolve, 100));
+            return new Promise((resolve) => setTimeout(resolve, 100));
         });
 
         it('should throw an error when making multiple open requests', () => {
@@ -254,8 +254,8 @@ describe('SignalingClient', () => {
             }).toThrow('Client is already open, opening, or closing');
         });
 
-        it('should emit an error event if the connection cannot be started', done => {
-            signer.mockImplementation(endpoint => new Promise((_, reject) => reject(new Error(endpoint))));
+        it('should emit an error event if the connection cannot be started', (done) => {
+            signer.mockImplementation((endpoint) => new Promise((_, reject) => reject(new Error(endpoint))));
             const client = new SignalingClient(config as SignalingClientConfig);
             client.on('error', () => {
                 done();
@@ -265,7 +265,7 @@ describe('SignalingClient', () => {
     });
 
     describe('close', () => {
-        it('should close an open connection', done => {
+        it('should close an open connection', (done) => {
             const client = new SignalingClient(config as SignalingClientConfig);
 
             // Open a channel, close it, then wait for the close event.
@@ -279,7 +279,7 @@ describe('SignalingClient', () => {
             client.open();
         });
 
-        it('should do nothing if the connection is closing', done => {
+        it('should do nothing if the connection is closing', (done) => {
             const client = new SignalingClient(config as SignalingClientConfig);
 
             // Open a channel, close it, try to close it again, then wait for the close event.
@@ -301,12 +301,12 @@ describe('SignalingClient', () => {
                 expect('Should not have fired an event').toBeFalsy();
             });
             client.close();
-            return new Promise(resolve => setTimeout(resolve, 100));
+            return new Promise((resolve) => setTimeout(resolve, 100));
         });
     });
 
     describe('sendSdpOffer', () => {
-        it('should send the message as the viewer', done => {
+        it('should send the message as the viewer', (done) => {
             const client = new SignalingClient(config as SignalingClientConfig);
             client.open();
             client.on('open', () => {
@@ -316,7 +316,7 @@ describe('SignalingClient', () => {
             });
         });
 
-        it('should send the message as the master', done => {
+        it('should send the message as the master', (done) => {
             config.role = Role.MASTER;
             delete config.clientId;
             const client = new SignalingClient(config as SignalingClientConfig);
@@ -333,7 +333,7 @@ describe('SignalingClient', () => {
             expect(() => client.sendSdpOffer(SDP_OFFER)).toThrow('Could not send message because the connection to the signaling service is not open.');
         });
 
-        it('should throw an error if there is a recipient id as viewer', done => {
+        it('should throw an error if there is a recipient id as viewer', (done) => {
             const client = new SignalingClient(config as SignalingClientConfig);
             client.open();
             client.on('open', () => {
@@ -346,7 +346,7 @@ describe('SignalingClient', () => {
     });
 
     describe('sendSdpAnswer', () => {
-        it('should send the message as the viewer', done => {
+        it('should send the message as the viewer', (done) => {
             const client = new SignalingClient(config as SignalingClientConfig);
             client.open();
             client.on('open', () => {
@@ -356,7 +356,7 @@ describe('SignalingClient', () => {
             });
         });
 
-        it('should throw an error if the correlationId is invalid', done => {
+        it('should throw an error if the correlationId is invalid', (done) => {
             const client = new SignalingClient(config as SignalingClientConfig);
             client.open();
             client.on('open', () => {
@@ -365,7 +365,7 @@ describe('SignalingClient', () => {
             });
         });
 
-        it('should send the message as the master', done => {
+        it('should send the message as the master', (done) => {
             config.role = Role.MASTER;
             delete config.clientId;
             const client = new SignalingClient(config as SignalingClientConfig);
@@ -382,7 +382,7 @@ describe('SignalingClient', () => {
             expect(() => client.sendSdpAnswer(SDP_ANSWER)).toThrow('Could not send message because the connection to the signaling service is not open.');
         });
 
-        it('should throw an error if there is a recipient id as viewer', done => {
+        it('should throw an error if there is a recipient id as viewer', (done) => {
             const client = new SignalingClient(config as SignalingClientConfig);
             client.open();
             client.on('open', () => {
@@ -395,7 +395,7 @@ describe('SignalingClient', () => {
     });
 
     describe('sendIceCandidate', () => {
-        it('should send the message as the viewer', done => {
+        it('should send the message as the viewer', (done) => {
             const client = new SignalingClient(config as SignalingClientConfig);
             client.open();
             client.on('open', () => {
@@ -405,7 +405,7 @@ describe('SignalingClient', () => {
             });
         });
 
-        it('should send the message as the master', done => {
+        it('should send the message as the master', (done) => {
             config.role = Role.MASTER;
             delete config.clientId;
             const client = new SignalingClient(config as SignalingClientConfig);
@@ -422,7 +422,7 @@ describe('SignalingClient', () => {
             expect(() => client.sendIceCandidate(ICE_CANDIDATE)).toThrow('Could not send message because the connection to the signaling service is not open.');
         });
 
-        it('should throw an error if there is a recipient id as viewer', done => {
+        it('should throw an error if there is a recipient id as viewer', (done) => {
             const client = new SignalingClient(config as SignalingClientConfig);
             client.open();
             client.on('open', () => {
@@ -435,7 +435,7 @@ describe('SignalingClient', () => {
     });
 
     describe('events', () => {
-        it('should ignore non-parsable messages from the signaling service', done => {
+        it('should ignore non-parsable messages from the signaling service', (done) => {
             const client = new SignalingClient(config as SignalingClientConfig);
 
             // Open a connection, receive a faulty message, and then continue to receive and process a non-faulty message.
@@ -451,7 +451,7 @@ describe('SignalingClient', () => {
         });
 
         describe('sdpOffer', () => {
-            it('should parse sdpOffer messages from the master', done => {
+            it('should parse sdpOffer messages from the master', (done) => {
                 const client = new SignalingClient(config as SignalingClientConfig);
                 client.once('sdpOffer', (sdpOffer, senderClientId) => {
                     expect(sdpOffer).toEqual(SDP_OFFER_OBJECT);
@@ -464,7 +464,7 @@ describe('SignalingClient', () => {
                 client.open();
             });
 
-            it('should parse sdpOffer messages from the viewer', done => {
+            it('should parse sdpOffer messages from the viewer', (done) => {
                 config.role = Role.MASTER;
                 delete config.clientId;
                 const client = new SignalingClient(config as SignalingClientConfig);
@@ -479,7 +479,7 @@ describe('SignalingClient', () => {
                 client.open();
             });
 
-            it('should parse sdpOffer messages from the master and release pending ICE candidates', done => {
+            it('should parse sdpOffer messages from the master and release pending ICE candidates', (done) => {
                 const client = new SignalingClient(config as SignalingClientConfig);
                 let count = 0;
                 client.once('sdpOffer', (sdpOffer, senderClientId) => {
@@ -504,7 +504,7 @@ describe('SignalingClient', () => {
         });
 
         describe('sdpAnswer', () => {
-            it('should parse sdpAnswer messages from the master', done => {
+            it('should parse sdpAnswer messages from the master', (done) => {
                 const client = new SignalingClient(config as SignalingClientConfig);
                 client.once('sdpAnswer', (sdpAnswer, senderClientId) => {
                     expect(sdpAnswer).toEqual(SDP_ANSWER_OBJECT);
@@ -517,7 +517,7 @@ describe('SignalingClient', () => {
                 client.open();
             });
 
-            it('should parse sdpAnswer messages from the viewer', done => {
+            it('should parse sdpAnswer messages from the viewer', (done) => {
                 config.role = Role.MASTER;
                 delete config.clientId;
                 const client = new SignalingClient(config as SignalingClientConfig);
@@ -532,7 +532,7 @@ describe('SignalingClient', () => {
                 client.open();
             });
 
-            it('should parse sdpAnswer messages from the master and release pending ICE candidates', done => {
+            it('should parse sdpAnswer messages from the master and release pending ICE candidates', (done) => {
                 const client = new SignalingClient(config as SignalingClientConfig);
                 client.once('sdpAnswer', (sdpAnswer, senderClientId) => {
                     expect(sdpAnswer).toEqual(SDP_ANSWER_OBJECT);
@@ -557,7 +557,7 @@ describe('SignalingClient', () => {
         });
 
         describe('iceCandidate', () => {
-            it('should parse iceCandidate messages from the master', done => {
+            it('should parse iceCandidate messages from the master', (done) => {
                 const client = new SignalingClient(config as SignalingClientConfig);
                 client.on('iceCandidate', (iceCandidate, senderClientId) => {
                     expect(iceCandidate).toEqual(ICE_CANDIDATE_OBJECT);
@@ -571,7 +571,7 @@ describe('SignalingClient', () => {
                 client.open();
             });
 
-            it('should parse iceCandidate messages from the viewer', done => {
+            it('should parse iceCandidate messages from the viewer', (done) => {
                 config.role = Role.MASTER;
                 delete config.clientId;
                 const client = new SignalingClient(config as SignalingClientConfig);
@@ -589,7 +589,7 @@ describe('SignalingClient', () => {
         });
 
         describe('statusResponse', () => {
-            it('should parse statusResponse message from signaling', done => {
+            it('should parse statusResponse message from signaling', (done) => {
                 config.role = Role.MASTER;
                 delete config.clientId;
                 const client = new SignalingClient(config as SignalingClientConfig);
@@ -607,10 +607,10 @@ describe('SignalingClient', () => {
     });
 
     describe('outsideBrowser', () => {
-        it('parseJSONObjectFromBase64String', done => {
+        it('parseJSONObjectFromBase64String', (done) => {
             global.atob = undefined;
             const client = new SignalingClient(config as SignalingClientConfig);
-            client.once('sdpAnswer', sdpAnswer => {
+            client.once('sdpAnswer', (sdpAnswer) => {
                 expect(sdpAnswer).toEqual(SDP_ANSWER_OBJECT);
                 done();
             });
@@ -620,7 +620,7 @@ describe('SignalingClient', () => {
             client.open();
         });
 
-        it('serializeJSONObjectAsBase64String', done => {
+        it('serializeJSONObjectAsBase64String', (done) => {
             global.btoa = undefined;
             const client = new SignalingClient(config as SignalingClientConfig);
             client.open();

--- a/src/SignalingClient.ts
+++ b/src/SignalingClient.ts
@@ -127,7 +127,7 @@ export class SignalingClient extends EventEmitter {
         // Therefore, we just kick off the asynchronous process and then return and let it fire events.
         this.asyncOpen()
             .then()
-            .catch(err => this.onError(err));
+            .catch((err) => this.onError(err));
     }
 
     /**
@@ -346,7 +346,7 @@ export class SignalingClient extends EventEmitter {
             return;
         }
         delete this.pendingIceCandidatesByClientId[clientIdKey];
-        pendingIceCandidates.forEach(iceCandidate => {
+        pendingIceCandidates.forEach((iceCandidate) => {
             this.emit('iceCandidate', iceCandidate, clientId);
         });
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bump eslint-plugin-prettier to v5.2.1 to fix prettier version bump.
New prettier version has new formatting requirements, ran linter (`npm run lint -- --fix`) to make the styling changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
