### PR TITLE
Auto-merge dependabot & retarget to develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,6 @@ updates:
       directory: /
       target-branch: develop
       schedule:
-          interval: daily
+          interval: weekly
       labels:
           - dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,22 @@ jobs:
         run: npm install
       - name: Run release
         run: npm run release
+
+  dependabot-auto-merge-after-ci-passes:
+    needs: nodejs-ubuntu-build
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    if: >-
+      github.actor == 'dependabot[bot]' &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.base.ref == 'develop'
+    env:
+      PR_URL: ${{ github.event.pull_request.html_url }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Approve Dependabot PR
+        run: gh pr review --approve "$PR_URL"
+      - name: Auto-merge Dependabot PR
+        run: gh pr merge --squash --auto "$PR_URL"

--- a/.github/workflows/retarget-dependabot-to-develop.yml
+++ b/.github/workflows/retarget-dependabot-to-develop.yml
@@ -1,0 +1,20 @@
+name: Retarget Dependabot PRs to develop
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  retarget-pull-request:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    permissions:
+      pull-requests: write
+      contents: read
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PR_URL: ${{ github.event.pull_request.html_url }}
+    steps:
+      - name: Change base branch to develop
+        run: gh pr edit "$PR_URL" --base develop


### PR DESCRIPTION
*Issue #, if available:*
- All the dependabot PRs

*Description of changes:*
1. Auto-merge dependabot PRs.
    - If the unit tests or build fails, the PR won't get merged until manual intervention (e.g. non-backwards compat. change in the dependency)
2. Auto-retarget pull requests from master to develop
    - Sometimes, Dependabot will create pull requests to master branch, which skips the usual development/release process. We will target those to develop.
3. Change the dependabot interval to 'weekly' to reduce the number of pull requests created (cluttering the pull requests tab in the repository).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
