### PR TITLE
Samples: Add the loadedData event listener only once

### DIFF
--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -268,12 +268,11 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, rem
         viewer.localView = localView;
         viewer.remoteView = remoteView;
 
-        viewer.remoteView.addEventListener('loadeddata', () => {
+        viewer.loadedDataCallback = () => {
             metrics.viewer.ttff.endTime = Date.now();
             if (formValues.enableProfileTimeline) {
                 metrics.viewer.ttffAfterPc.endTime = metrics.viewer.ttff.endTime;
                 metrics.master.ttffAfterPc.endTime = metrics.viewer.ttff.endTime;
-
 
                 // if the ice-gathering on the master side is not complete by the time the metrics are sent, the endTime > startTime
                 // in order to plot it, we can show it as an ongoing process
@@ -281,11 +280,13 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, rem
                     metrics.master.iceGathering.endTime = metrics.viewer.ttff.endTime;
                 }
             }
-            if(formValues.enableDQPmetrics) {
+            if (formValues.enableDQPmetrics) {
                 timeToFirstFrameFromOffer = metrics.viewer.ttff.endTime - metrics.viewer.offAnswerTime.startTime;
                 timeToFirstFrameFromViewerStart = metrics.viewer.ttff.endTime - viewerButtonPressed.getTime();
             }
-        });
+        };
+
+        viewer.remoteView.addEventListener('loadeddata', viewer.loadedDataCallback);
 
         if (formValues.enableProfileTimeline) {
             metrics.viewer.ttff.startTime = viewerButtonPressed.getTime();
@@ -818,6 +819,7 @@ function stopViewer() {
         }
 
         if (viewer.remoteView) {
+            viewer.remoteView.removeEventListener('loadeddata');
             viewer.remoteView.srcObject = null;
         }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Only add the loadedData listener once. 
- Currently, the listener gets added each time the viewer button is pressed. 
- LoadedData event listener is used for metrics collection (first frame playable) - https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/loadeddata_event

Verified the behavior by adding a log line inside of the callback and observed it being called multiple times per run.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
