### PR TITLE
Samples: Signaling reconnect and refresh/cache turn credentials

### DIFF
--- a/aws-sdk-build/rename-output-file.js
+++ b/aws-sdk-build/rename-output-file.js
@@ -1,16 +1,17 @@
-const fs = require("fs");
-const path = require("path");
-const execSync = require("child_process").execSync;
+const fs = require('fs');
+const path = require('path');
+const execSync = require('child_process').execSync;
 
 // Get the version from package.json
-const version_kvs = JSON.parse(execSync("npm list @aws-sdk/client-kinesis-video --depth=0 --json"))
-    .dependencies["@aws-sdk/client-kinesis-video"].version;
+const version_kvs = JSON.parse(execSync('npm list @aws-sdk/client-kinesis-video --depth=0 --json')).dependencies['@aws-sdk/client-kinesis-video'].version;
 
-const version_kvs_signaling = JSON.parse(execSync("npm list @aws-sdk/client-kinesis-video-signaling --depth=0 --json"))
-    .dependencies["@aws-sdk/client-kinesis-video-signaling"].version;
+const version_kvs_signaling = JSON.parse(execSync('npm list @aws-sdk/client-kinesis-video-signaling --depth=0 --json')).dependencies[
+    '@aws-sdk/client-kinesis-video-signaling'
+].version;
 
-const version_kvs_webrtc_storage = JSON.parse(execSync("npm list @aws-sdk/client-kinesis-video-webrtc-storage --depth=0 --json"))
-    .dependencies["@aws-sdk/client-kinesis-video-webrtc-storage"].version;
+const version_kvs_webrtc_storage = JSON.parse(execSync('npm list @aws-sdk/client-kinesis-video-webrtc-storage --depth=0 --json')).dependencies[
+    '@aws-sdk/client-kinesis-video-webrtc-storage'
+].version;
 
 if (version_kvs !== version_kvs_signaling || version_kvs !== version_kvs_webrtc_storage) {
     throw `Version mismatch!
@@ -20,7 +21,7 @@ if (version_kvs !== version_kvs_signaling || version_kvs !== version_kvs_webrtc_
 }
 
 // Path to the Webpack output directory
-const distDir = path.resolve(__dirname, "dist");
+const distDir = path.resolve(__dirname, 'dist');
 
 // Find the generated Webpack file
 const oldFileName = path.join(distDir, 'aws-sdk-VERSION-kvswebrtc.js');
@@ -29,8 +30,8 @@ const newFileName = path.join(distDir, `aws-sdk-${version_kvs}-kvswebrtc.js`);
 // Rename the file
 fs.rename(oldFileName, newFileName, (err) => {
     if (err) {
-        console.error("Error renaming file:", err);
+        console.error(`Error renaming ${oldFileName} to ${newFileName}:`, err);
     } else {
-        console.log(`Renamed file to: ${newFileName}`);
+        console.log(`Renamed ${oldFileName} to: ${newFileName}`);
     }
 });

--- a/examples/app.js
+++ b/examples/app.js
@@ -106,6 +106,7 @@ function getFormValues() {
         sendUdpCandidates: $('#send-udp').is(':checked'),
         acceptUdpCandidates: $('#accept-udp').is(':checked'),
         mediaIngestionModeOverride: $('#ingest-media-manual-on').attr('data-selected') === 'true',
+        signalingReconnect: $('#signaling-reconnect').is(':checked'),
         logAwsSdkCalls: $('#log-aws-sdk-calls').is(':checked'),
     };
 }
@@ -547,6 +548,7 @@ const fields = [
     {field: 'accept-tcp', type: 'checkbox'},
     {field: 'send-udp', type: 'checkbox'},
     {field: 'accept-udp', type: 'checkbox'},
+    {field: 'signaling-reconnect', type: 'checkbox'},
     {field: 'log-aws-sdk-calls', type: 'checkbox'},
 ];
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -208,7 +208,7 @@
             </div>
 
             <details><summary class="h4">Advanced</summary>
-                <p><small>Filter settings for which ICE candidates are sent to and received from the peer.</small></p>
+                <p class="mt-3"><small>Filter settings for which ICE candidates are sent to and received from the peer.</small></p>
                 <div class="container">
                     <div class="row">
                         <div class="col-sm">
@@ -261,6 +261,18 @@
                             <div class="form-check">
                                 <input class="form-check-input" type="checkbox" id="accept-udp" checked />
                                 <label for="accept-udp" class="form-check-label">Accept <code>udp</code> candidates from peer</label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <p class="mt-3"><small>Signaling reconnect</small></p>
+                <div class="container">
+                    <div class="row">
+                        <div class="col-sm">
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" id="signaling-reconnect" checked/>
+                                <label for="signaling-reconnect" class="form-check-label">Reopen signaling connection
+                                    after idle timeout <small>(Master only, non WebRTC ingestion)</small></label>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
*Issue #, if available:*
- #83, #86, #286

*Description of changes:*

### Background
- Currently, the sample application only fetches TURN servers when the button is clicked. TURN server credentials (used to initiate a TURN server connection) expire after 5 minutes (300 seconds).
- Therefore, if you try to re-initiate a connection (e.g. JoinStorageSession again after the 1 hour limit), the connection will fail if TURN is required on the client side.
- Signaling also has a 10-minute idle timeout. If there is no signaling channel activity for 10 minutes, you get disconnected.

### Summary

This PR introduces a more robust mechanism for managing ICE server credentials and optionally supports automatic signaling reconnection in master mode. It also improves logging and enhances maintainability by cleaning up redundant code and clarifying logic flows.

### Changes

* Added logic to cache the ICE servers and refresh them **only when needed**, specifically upon receiving an SDP offer.
  * Improves scalability by avoiding unnecessary network usage ensuring efficient use of both browser and backend resources.
  * TURN credentials are cached in-memory (for the current run), and they are not written to localStorage or cookies.
* Added new checkbox (signaling-reconnect) to the UI for enabling signaling reconnection after idle timeout.
  * When enabled (and ingestion mode is not active), the master client will automatically attempt to reopen the signaling channel upon disconnection. (Ideally, we'd use ping frames, but browsers do not have support for it)

### Minor Changes

* Ran linter on the `rename-output-file.js`
* Address comment regarding the log line in `rename-output-file.js` from #426
* Minor HTML spacing tweak to improve layout under the Advanced settings.

### Testing

* Check JoinStorageSession automatically reconnects with the TURN after 1 hour (and GetIceServerConfig is called again).
* Confirmed signaling reconnect triggers on idle disconnect when checkbox is enabled.
* Check master with the signaling reconnect feature can still have viewers joining via TURN more than 5 minutes after the button is pressed.
* Regression tested existing master/viewer flows across default and advanced settings.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
