### PR TITLE
Correct comment about file size for optimized build

### DIFF
--- a/aws-sdk-build/webpack.config.js
+++ b/aws-sdk-build/webpack.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 // 1.8 MB approximately for development build with sourcemap
-// about 330 KB for the optimized build
+// about 162 KB for the optimized build
 const isProduction = process.env.CI === 'true';
 
 module.exports = {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Correcting the file size of the artifact. It is 162 KB, not 330 KB.

```
ls -tlrh dist
total 328
-rw-r--r--@ 1 me  staff   162K Apr 11 13:09 aws-sdk-3.758.0-kvswebrtc.js
```

Also checked in GitHub UI:

<img width="485" alt="image" src="https://github.com/user-attachments/assets/5e7fd835-c974-4969-8736-b565c3445549" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
