### PR TITLE
Cleanup listeners properly

### DIFF
--- a/examples/master.js
+++ b/examples/master.js
@@ -16,6 +16,7 @@ const masterDefaults = {
     currentJoinStorageSessionRetries: 0,
     turnServerExpiryTs: 0, // Epoch millis when the TURN servers expire minus grace period
     iceServers: [], // Cached list of ICE servers (STUN and TURN, depending on formValues)
+    reopenChannelCallback: null,
 };
 
 let master = {};
@@ -372,7 +373,9 @@ function stopMaster() {
         master.sdpOfferReceived = true;
 
         // Remove the callback that reopens the connection on 'close' before attempting to close the connection
-        master.channelHelper?.getSignalingClient()?.removeListener('close', master.reopenChannelCallback);
+        if (master.reopenChannelCallback) {
+            master.channelHelper?.getSignalingClient()?.removeListener('close', master.reopenChannelCallback);
+        }
         master.channelHelper?.getSignalingClient()?.close();
 
         Object.keys(master.peerByClientId).forEach(clientId => {

--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -819,7 +819,7 @@ function stopViewer() {
         }
 
         if (viewer.remoteView) {
-            viewer.remoteView.removeEventListener('loadeddata');
+            viewer.remoteView.removeEventListener('loadeddata', viewer.loadedDataCallback);
             viewer.remoteView.srcObject = null;
         }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fix two issues in the test page:

(1) occurs when clicking stopMaster with WebRTC ingestion since the listener wasn't added

```
[2025-04-15T17:36:57.226Z] [ERROR] [MASTER] Encountered error stopping TypeError: The "listener" argument must be of type Function. Received type undefined
    at checkListener (https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-js/develop/kvs-webrtc.js:89:11)
    at SignalingClient.removeListener (https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-js/develop/kvs-webrtc.js:290:7)
    at stopMaster (https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-js/develop/examples/master.js:375:53)
    at HTMLButtonElement.onStop (https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-js/develop/examples/app.js:133:9)
    at HTMLButtonElement.dispatch (https://code.jquery.com/jquery-3.3.1.slim.min.js:2:41964)
    at HTMLButtonElement.<anonymous> (https://code.jquery.com/jquery-3.3.1.slim.min.js:2:39983)
```

(2) occurs when clicking StopViewer since the function was not passed as an argument.

```
[2025-04-15T17:38:58.472Z] [ERROR] [VIEWER] Encountered error stopping {
  "message": "Failed to execute 'removeEventListener' on 'EventTarget': 2 arguments required, but only 1 present."
}
TypeError: 2 arguments required, but only 1 present.
    at stopViewer (https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-js/develop/examples/viewer.js:822:31)
    at HTMLButtonElement.onStop (https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-js/develop/examples/app.js:144:9)
    at HTMLButtonElement.dispatch (https://code.jquery.com/jquery-3.3.1.slim.min.js:2:41964)
    at HTMLButtonElement.<anonymous> (https://code.jquery.com/jquery-3.3.1.slim.min.js:2:39983)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
