### PR TITLE
Don't run the npm publish step on forks

### DIFF
--- a/.github/workflows/master-publish-gh-pages-and-npm.yml
+++ b/.github/workflows/master-publish-gh-pages-and-npm.yml
@@ -40,5 +40,7 @@ jobs:
                   rm -rf aws-sdk-build
             - name: Deploy to npm packages
               uses: JS-DevTools/npm-publish@v1
+              # Don't run this step for forks, only in the original repo
+              if: github.repository == 'awslabs/amazon-kinesis-video-streams-webrtc-sdk-js'
               with:
                   token: '${{ secrets.NPM_TOKEN }}'


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*Description of changes:*
- Add a condition for the 'publish to npm' step to be automatically skipped on forks.
- One less thing builders have to worry about so they can spend more time focusing on developing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
