### PR TITLE
Samples: Fix syntax error with JoinStorageSessionAsViewer command

### DIFF
--- a/examples/master.js
+++ b/examples/master.js
@@ -469,7 +469,7 @@ async function callJoinStorageSessionUntilSDPOfferReceived(runId) {
             } else {
                 await master.channelHelper
                     .getWebRTCStorageClient()
-                    .send(AWS.KinesisVideoWebRTCStorage.JoinStorageSessionAsViewerCommand({
+                    .send(new AWS.KinesisVideoWebRTCStorage.JoinStorageSessionAsViewerCommand({
                         channelArn: master.channelHelper.getChannelArn(),
                         clientId: master.clientId,
                     }));


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*Description of changes:*
- Fix a syntax error with JoinStorageSessionAsViewer command during the migration from AWS SDK JS V2 to V3.
- To fix the error:
```
TypeError: Class constructor bd cannot be invoked without 'new'
    at callJoinStorageSessionUntilSDPOfferReceived (https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-js/examples/master.js:472:57)
    at connectToMediaServer (https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-js/examples/master.js:503:27)
    at SignalingClient.<anonymous> (https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-js/examples/master.js:178:19)
    at SignalingClient.emit (https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-js/kvs-webrtc.js:170:5)
    at __webpack_modules__../src/SignalingClient.ts.SignalingClient.onOpen (https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-js/kvs-webrtc.js:1476:14)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.