### PR TITLE
TURN filter options

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -120,6 +120,10 @@ function getFormValues() {
         mediaIngestionModeOverride: $('#ingest-media-manual-on').attr('data-selected') === 'true',
         signalingReconnect: $('#signaling-reconnect').is(':checked'),
         logAwsSdkCalls: $('#log-aws-sdk-calls').is(':checked'),
+        turnWithUdp: $('#turn-with-udp').is(':checked'),
+        turnsWithUdp: $('#turns-with-udp').is(':checked'),
+        turnsWithTcp: $('#turns-with-tcp').is(':checked'),
+        oneTurnServerSetOnly: $('#turn-one-set-only').is(':checked'),
     };
 }
 
@@ -563,6 +567,10 @@ const fields = [
     {field: 'signaling-reconnect', type: 'checkbox'},
     {field: 'log-aws-sdk-calls', type: 'checkbox'},
     {field: 'codec-filter-toggle', type: 'checkbox'},
+    {field: 'turn-with-udp', type: 'checkbox'},
+    {field: 'turns-with-udp', type: 'checkbox'},
+    {field: 'turns-with-tcp', type: 'checkbox'},
+    {field: 'turn-one-set-only', type: 'checkbox'},
 ];
 
 fields.forEach(({field, type, name}) => {

--- a/examples/index.html
+++ b/examples/index.html
@@ -317,6 +317,27 @@
                         </div>
                     </div>
                 </div>
+                <p class="mt-3"><small>TURN connection options</small><span data-delay="{ &quot;hide&quot;: 1500 }" data-position="auto" tabindex="0" class="text-info ml-1" data-toggle="tooltip" data-html="true" title="
+                                <p>Filter options for the URLs from the GetIceServerConfig API call.</p>"><sup>&#9432;</sup></span></p>
+                <div class="mt-3 mb-3 container">
+                    <div class="form-check form-switch">
+                        <input class="form-check-input" type="checkbox" id="turn-with-udp" checked>
+                        <label class="form-check-label" for="turn-with-udp">TURN with UDP</label>
+                    </div>
+                    <div class="form-check form-switch">
+                        <input class="form-check-input" type="checkbox" id="turns-with-udp" checked>
+                        <label class="form-check-label" for="turns-with-udp">TURNS with UDP</label>
+                    </div>
+                    <div class="form-check form-switch">
+                        <input class="form-check-input" type="checkbox" id="turns-with-tcp" checked>
+                        <label class="form-check-label" for="turns-with-tcp">TURNS with TCP</label>
+                    </div>
+                    <div class="form-check form-switch">
+                        <input class="form-check-input" type="checkbox" id="turn-one-set-only" checked>
+                        <label class="form-check-label" for="turn-one-set-only">Use only one set of TURN servers<span data-delay="{ &quot;hide&quot;: 1500 }" data-position="auto" tabindex="0" class="text-info ml-1" data-toggle="tooltip" data-html="true" title="
+                            <p>GetIceServerConfig returns two sets of TURN servers, only use one of the sets.</p>"><sup>&#9432;</sup></span></label>
+                    </div>
+                </div>
                 <p class="mt-3"><small>Endpoint Override</small></p>
                 <div class="form-group">
                     <input type="text" class="form-control" id="endpoint" placeholder="Endpoint">


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/issues/92

*Description of changes:*
- Added TURN server filtering to reduce the number of redundant ICE candidates gathered.
- As the number of ICE candidates gathered increases, the number of pairs increases exponentially. Generating less pairs means devices have less combinations to try, reducing overall network bandwidth used for the ICE negotiation.

<details><summary>Currently returned by GetIceServerConfig</summary> 

```
{
    "IceServerList": [
        {
            "Uris": [
                "turn:x-x-x-x.t-xxxx.kinesisvideo.us-west-2.amazonaws.com:443?transport=udp",
                "turns:x-x-x-x.t-xxxx.kinesisvideo.us-west-2.amazonaws.com:443?transport=udp",
                "turns:x-x-x-138.t-xxxx.kinesisvideo.us-west-2.amazonaws.com:443?transport=tcp"
            ],
            "Username": "x",
            "Password": "x",
            "Ttl": 300
        },
        {
            "Uris": [
                "turn:x-x-x-x.t-xxxx.kinesisvideo.us-west-2.amazonaws.com:443?transport=udp",
                "turns:x-x-x-x.t-xxxx.kinesisvideo.us-west-2.amazonaws.com:443?transport=udp",
                "turns:x-x-x-x.t-xxxx.kinesisvideo.us-west-2.amazonaws.com:443?transport=tcp"
            ],
            "Username": "x",
            "Password": "x",
            "Ttl": 300
        }
    ]
}
```

</details>

The new checkboxes look like this, in the 'Advanced' section, and all of them are ON by default.

<img width="367" alt="image" src="https://github.com/user-attachments/assets/65f5fea4-b9f7-45f6-ae1b-6793aab49ba5" />

Testing:
- Reloaded the page after changing some options to check the saving option values to localStorage
- Unchecked one of the boxes to verify that TURN server was removed
- Unchecked the last box to make sure that both sets are used when it's unchecked

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
