### PR TITLE
Adjust logging for tracks & mediaStream

### DIFF
--- a/examples/answerer.js
+++ b/examples/answerer.js
@@ -127,7 +127,17 @@ class Answerer {
         // We receive this event when the remote peer adds a new track to the PeerConnection
         // https://webrtc.org/getting-started/remote-streams#adding_remote_tracks
         this._peerConnection.addEventListener('track', event => {
-            console.log(this._loggingPrefix, 'Received track from', this._remoteClientId || 'remote', 'with track id:', event?.streams[0]?.id ?? '[Error retrieving track ID]');
+            console.log(
+                this._loggingPrefix,
+                'Received',
+                event.track.kind || 'unknown',
+                'track from',
+                this._remoteClientId || 'remote',
+                'in mediaStream:',
+                event?.streams[0]?.id ?? '[Error retrieving stream ID]',
+                'with track id:',
+                event.track.id,
+            );
             this._onMediaStreamsUpdated(event.streams);
         });
 

--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -775,8 +775,7 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, rem
         // As remote tracks are received, add them to the remote view
         viewer.peerConnection.addEventListener('track', event => {
             console.log(
-                this._loggingPrefix,
-                'Received',
+                '[VIEWER] Received',
                 event.track.kind || 'unknown',
                 'track from',
                 this._remoteClientId || 'remote',

--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -774,7 +774,17 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, rem
 
         // As remote tracks are received, add them to the remote view
         viewer.peerConnection.addEventListener('track', event => {
-            console.log('[VIEWER] Received remote track with id:', event?.streams[0]?.id ?? '[Error retrieving track ID]');
+            console.log(
+                this._loggingPrefix,
+                'Received',
+                event.track.kind || 'unknown',
+                'track from',
+                this._remoteClientId || 'remote',
+                'in mediaStream:',
+                event?.streams[0]?.id ?? '[Error retrieving stream ID]',
+                'with track id:',
+                event.track.id,
+            );
             if (remoteView.srcObject) {
                 return;
             }


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*Description of changes:*
- Making it easier to debug when tracks are received (adding more information).

Before:
```
[2025-05-13T03:04:27.889Z] [INFO] [MASTER] Received track from ConsumerViewer_170674682 with track id: myKvsVideoStream
[2025-05-13T03:04:27.890Z] [INFO] [MASTER] Received track from ConsumerViewer_170674682 with track id: myKvsVideoStream
```

After:
```
[2025-05-13T03:05:12.151Z] [INFO] [MASTER] Received audio track from ConsumerViewer_1894618893 in mediaStream: myKvsVideoStream with track id: 400fab0b-7005-4c9f-9c36-d2071df8fe47
[2025-05-13T03:05:12.153Z] [INFO] [MASTER] Received video track from ConsumerViewer_1894618893 in mediaStream: myKvsVideoStream with track id: 7d362d86-46f9-48a2-ba8a-91151b4b0479
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
