### PR TITLE
ci: scope down GitHub Token permissions

### DIFF
--- a/.github/workflows/develop-publish-gh-pages.yml
+++ b/.github/workflows/develop-publish-gh-pages.yml
@@ -4,6 +4,10 @@ on:
     push:
         branches:
             - develop
+permissions:
+  contents: write
+  pages: write
+
 jobs:
     publish-ubuntu-build:
         runs-on: ubuntu-latest

--- a/.github/workflows/master-publish-gh-pages-and-npm.yml
+++ b/.github/workflows/master-publish-gh-pages-and-npm.yml
@@ -4,6 +4,9 @@ on:
     push:
         branches:
             - master
+permissions:
+  contents: read
+
 jobs:
     publish-ubuntu-build:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Scope Down GitHub Token Permissions

This PR updates GitHub Actions workflows to use minimal required permissions instead of the default elevated permissions.

### Why This Matters

Following the principle of least privilege, workflows should only have the specific permissions they need to function.

### Changes

This PR adds explicit `permissions:` blocks to workflows that currently rely on default permissions, scoping them down to only what's required for their operations.

Please review the changes to ensure the specified permissions match your workflow requirements.