### PR TITLE
Fix Firefox compatibility by handling null ICE candidates

### DIFF
--- a/examples/answerer.js
+++ b/examples/answerer.js
@@ -97,7 +97,7 @@ class Answerer {
             // `candidate` will be the empty string if the event indicates that there are no further candidates
             // to come in this generation, or null if all ICE gathering on all transports is complete.
             // https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/icecandidate_event
-            if (candidate) {
+            if (candidate && candidate.candidate) {
                 console.log(this._loggingPrefix, 'Generated ICE candidate for', this._remoteClientId || 'remote');
                 console.debug(this._loggingPrefix, 'ICE candidate:', candidate);
 
@@ -110,6 +110,8 @@ class Answerer {
                         console.log(this._loggingPrefix, 'Not sending ICE candidate to', this._remoteClientId || 'remote');
                     }
                 }
+            } else if (candidate && !candidate.candidate) {
+                    //firefox special case, candidate with null candidate field
             } else {
                 console.log(this._loggingPrefix, 'All ICE candidates have been generated for', this._remoteClientId || 'remote');
 

--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -769,7 +769,7 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, rem
 
         // Send any ICE candidates to the other peer
         viewer.peerConnection.addEventListener('icecandidate', ({ candidate }) => {
-            if (candidate) {
+            if (candidate && candidate.candidate) {
                 console.log('[VIEWER] Generated ICE candidate');
                 console.debug('ICE candidate:', candidate);
 
@@ -782,6 +782,8 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, rem
                         console.log('[VIEWER] Not sending ICE candidate');
                     }
                 }
+            } else if (candidate && !candidate.candidate) {
+                //firefox special case, candidate with null candidate field
             } else {
                 console.log('[VIEWER] All ICE candidates have been generated');
 


### PR DESCRIPTION
*Issue #, if available:*
- Firefox sends a null candidate to signal end of ICE gathering, which caused parsing errors when trying to process these candidates.

*Description of changes:*
- Add null checks before sending ICE candidates 
- Prevents errors when ICE gathering completes and the candidate with field 'candidate' being null is sent

BEFORE
<img width="825" height="194" alt="image" src="https://github.com/user-attachments/assets/e2ef4080-62fd-4dc4-99f2-0a1b680b9fee" />


AFTER
<img width="962" height="303" alt="image" src="https://github.com/user-attachments/assets/16016a8d-686b-4a18-b22b-d369464fa8ed" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
