### PR TITLE
Add method existence check for getSelectedCandidatePair

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -469,6 +469,39 @@ async function printPeerConnectionStateInfo(event, logPrefix, remoteClientId) {
                         console.debug(`Chosen candidate pair (${trackType || 'unknown'}):`, iceTransport.getSelectedCandidatePair());
                     iceTransport.onselectedcandidatepairchange = logSelectedCandidate;
                     logSelectedCandidate();
+                } else {
+                    // Find nominated candidate pair
+                    const nominatedPair = Array.from(stats.values()).find(report => 
+                    report.type === 'candidate-pair' && 
+                    report.nominated === true
+                    );
+            
+                    if (nominatedPair) {
+                        // Get local and remote candidate detailsl;                     
+                        const localCandidate = stats.get(nominatedPair.localCandidateId);
+                        const remoteCandidate = stats.get(nominatedPair.remoteCandidateId);
+                        
+                        if (localCandidate && remoteCandidate) {
+                            console.debug(`Chosen candidate pair (${trackType || 'unknown'}):`, {
+                                local: {
+                                    id: localCandidate.id,
+                                    address: localCandidate.address,
+                                    port: localCandidate.port,
+                                    type: localCandidate.candidateType,
+                                    protocol: localCandidate.protocol,
+                                    priority: localCandidate.priority
+                                },
+                                remote: {
+                                    id: remoteCandidate.id,
+                                    address: remoteCandidate.address,
+                                    port: remoteCandidate.port,
+                                    type: remoteCandidate.candidateType,
+                                    protocol: remoteCandidate.protocol,
+                                    priority: remoteCandidate.priority
+                                }
+                            });
+                        }
+                    }
                 }
             } else {
                 console.error('Failed to fetch the candidate pair!');


### PR DESCRIPTION
*Issue:*
- Firefox doesn't implement the getSelectedCandidatePair() method, causing runtime errors when the application attempts to call this method.

*Description of changes:*
- Added method existence check before calling it.
- Add fallback method to log selected ICE candidate pairs when getSelectedCandidatePair() is not supported

BEFORE:
<img width="1116" height="298" alt="image" src="https://github.com/user-attachments/assets/229c59ff-cc1c-47f2-9f3e-402546a7241b" />


AFTER:
<img width="1110" height="564" alt="image" src="https://github.com/user-attachments/assets/02222501-6378-41fc-99b7-c83555a864b8" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
