### PR TITLE
feat: add view URL parameter for auto-starting master/viewer mode

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -978,6 +978,16 @@ $('#codec-filter-toggle').on('change', (event) => {
 
 $(document).ready(() => {
     loadCodecPreferences();
+    
+    // click start based on the url params
+    if (urlParams.has('view')) {
+        const viewMode = urlParams.get('view');
+        if (viewMode === 'master') {
+            $('#master-button').click();
+        } else if (viewMode === 'viewer') {
+            $('#viewer-button').click();
+        }
+    }
 });
 
 /**


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*Description of changes:*
_What was changed?_
- Added a new view URL parameter that automatically starts the WebRTC demo in either master or viewer mode when the page loads.

_Why was it changed?_
- To enable automated testing without requiring manual interaction.

_How was it changed?_
- Added URL parameter parsing logic in the $(document).ready() function

_What testing was done for the changes?_
- Verified ?view=master automatically starts master mode
- Verified ?view=viewer automatically starts viewer mode

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
