### PR TITLE
Keeping clientID short for the media ingestion in the interim

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -76,8 +76,7 @@ function configureLogging() {
 function getRandomClientId() {
     const timestamp = Date.now().toString(36);
     const random = Math.random().toString(36).substring(2);
-    const uaBase64 = btoa(navigator.userAgent).replace(/\//g, '_').replace(/\+/g, '-').replace(/=/g, '');
-    return `${timestamp}-${random}-${uaBase64}`;
+    return `${timestamp}-${random}`;
 }
 
 function getTabScopedClientID() {


### PR DESCRIPTION
*Issue #, if available:*
- Longer clientID for media server failed.

*Description of changes:*
- Keep the cliendID short for the media ingestion in the interim.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
