### PR TITLE
Change URL for fetching regional data

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -364,7 +364,7 @@ async function logLevelSelected(event) {
 }
 
 // Fetch regions
-fetch('https://api.regional-table.region-services.aws.a2z.com/index.jsons')
+fetch('https://api.regional-table.region-services.aws.a2z.com/index.json')
     .then(res => {
         if (res.ok) {
             return res.json();


### PR DESCRIPTION
*Issue #, if available:*
- #673 

*Description of changes:*
- Seems the file no longer exists. Visiting the link takes us to a 404 page, whereas the resource previously existed (https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/pull/228)

```
<Code>NoSuchKey</Code>
<Message>The specified key does not exist.</Message>
<Key>index.jsons</Key>
```

- I tried changing the link to remove the 's' and it seems that that resource exists: `https://api.regional-table.region-services.aws.a2z.com/index.json` so changing it to that

<img width="774" height="153" alt="image" src="https://github.com/user-attachments/assets/53f6a118-07c4-4566-a558-440ac90489d9" />

*Testing:*
- Ran locally with the updated URL and verified the functionality of the region input box

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
