### PR TITLE
Fix undefined channelHelper check

### DIFF
--- a/examples/master.js
+++ b/examples/master.js
@@ -286,7 +286,7 @@ registerMasterSignalingClientCallbacks = (signalingClient, formValues, onStatsRe
 
 function onPeerConnectionFailed(remoteClientId, printLostConnectionLog = true) {
     const role = ROLE;
-    if (master?.channelHelper.isIngestionEnabled()) {
+    if (master?.channelHelper?.isIngestionEnabled()) {
         if (printLostConnectionLog) {
             console.warn(`[${ROLE}] Lost connection to the storage session.`);
         }


### PR DESCRIPTION
*Issue #, if available:*
- In the viewer mode, if the master connection fails, then we will see the following log:

Chrome
```
[2025-12-12T21:46:51.012Z] [ERROR] [VIEWER] Connection to peer failed!
[2025-12-12T21:46:51.017Z] [ERROR] TypeError: Cannot read properties of undefined (reading 'isIngestionEnabled')
```

Firefox
```
[2025-12-12T21:47:45.200Z] [ERROR] [VIEWER] Connection to peer failed!
[2025-12-12T21:47:45.206Z] [ERROR] TypeError: can't access property "isIngestionEnabled", master.channelHelper is undefined
```

*Description of changes:*

Context:
- Both master and viewer (P2P and ingestion mode) register `printPeerConnectionStateInfo` function to the `PeerConnection.connectionstatechange` callback.
- When the `printPeerConnectionStateInfo` changes to `failed`, it calls 'onPeerConnectionFailed'
- In the 'onPeerConnectionFailed', it checks `if (master?.channelHelper.isIngestionEnabled()) {` to check if the channel is in the ingestion mode to call JoinStorageSession again.

In the Viewer P2P mode, `master` object is empty object `{}`.

In JS, empty object is a **truthy** value, so `channelHelper` will be undefined and then it tries de-referencing undefined.

The change made fixes the issue by checking also if `channelHelper` is undefined before accessing the value.

*Testing:*

Ran the updated changes locally for P2P viewer and that error log does not show up anymore.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
