### PR TITLE
Migrate to OIDC trusted publishing

### DIFF
--- a/.github/workflows/develop-publish-gh-pages.yml
+++ b/.github/workflows/develop-publish-gh-pages.yml
@@ -11,9 +11,9 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@master
             - name: Use Node.js
-              uses: actions/setup-node@v2
+              uses: actions/setup-node@v4
               with:
-                  node-version: 22
+                  node-version: 24
             - name: Build AWS SDK
               working-directory: ./aws-sdk-build
               run: |

--- a/.github/workflows/master-publish-gh-pages-and-npm.yml
+++ b/.github/workflows/master-publish-gh-pages-and-npm.yml
@@ -7,13 +7,16 @@ on:
 jobs:
     publish-ubuntu-build:
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            id-token: write  # Needed for OIDC publishing
         steps:
             - name: Checkout repository
               uses: actions/checkout@master
             - name: Use Node.js
-              uses: actions/setup-node@v2
+              uses: actions/setup-node@v5
               with:
-                  node-version: 22
+                  node-version: 24
             - name: Build AWS SDK
               working-directory: ./aws-sdk-build
               run: |
@@ -39,8 +42,6 @@ jobs:
                   # Remove the infra to build the AWS SDK v3 browser script
                   rm -rf aws-sdk-build
             - name: Deploy to npm packages
-              uses: JS-DevTools/npm-publish@v1
+              uses: JS-DevTools/npm-publish@v4
               # Don't run this step for forks, only in the original repo
               if: github.repository == 'awslabs/amazon-kinesis-video-streams-webrtc-sdk-js'
-              with:
-                  token: '${{ secrets.NPM_TOKEN }}'


### PR DESCRIPTION
*Issue #, if available:*
- https://github.blog/changelog/2025-12-09-npm-classic-tokens-revoked-session-based-auth-and-cli-token-management-now-available/

*Description of changes:*
- Migrate to use OIDC trusted publishing
- Followed the instructions:
  - https://docs.npmjs.com/trusted-publishers
  - https://github.com/JS-DevTools/npm-publish


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
