### PR TITLE
feat: add events package to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
         "webpack-merge": "^6.0.1"
     },
     "dependencies": {
+        "events": "^3.3.0",
         "isomorphic-webcrypto": "^2.3.6",
         "jsdom": "^27.0.0",
         "tslib": "^2.8.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,4 +11,4 @@ export { SigV4RequestSigner } from './SigV4RequestSigner';
 export { QueryParams } from './QueryParams';
 export { RequestSigner } from './RequestSigner';
 
-export const VERSION = process.env.PACKAGE_VERSION;
+export const VERSION = '2.5.0';


### PR DESCRIPTION
*Issue #, if available:*
Customer reported bundling issues when using the library as an npm package for browser environments:
- Trying to use the library as npm package and bundle it for browser
- Importing with: `import { Role, SignalingClient } from 'amazon-kinesis-video-streams-webrtc'`
- Two undocumented requirements needed for compilation:
  - Must add the dependency 'events' manually
  - Must add an alias for `process.env.PACKAGE_VERSION`
- Poor developer experience (DX) due to these manual steps

*Description of changes:*
- Add "events ^3.3.0" to package.json dependencies
- Static version string "2.4.6" replaces dynamic environment variable **process.env.PACKAGE_VERSION**

**Before:**
<img width="468" height="103" alt="image" src="https://github.com/user-attachments/assets/21f344cf-2a7d-459b-9a14-d9eeb7f3a550" />
<img width="468" height="84" alt="image" src="https://github.com/user-attachments/assets/5aa24fb9-d5f8-4f54-8e91-5f1597ebac50" />

**After:**
Tested with HTML and verified that SignalingClient can be imported successfully without requiring customer configuration changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
