### PR TITLE
Add GO_AWAY message handling support

### DIFF
--- a/examples/master.js
+++ b/examples/master.js
@@ -274,6 +274,13 @@ registerMasterSignalingClientCallbacks = (signalingClient, formValues, onStatsRe
         console.error(`[${role}] Signaling client error`, error);
     });
 
+    signalingClient.on('goAway', (message, senderClientId) => {
+        console.warn(`[${role}] Received GO_AWAY message from signaling service`);
+        console.log(`[${role}] Signaling service requested connection closure. Stopping master connection.`);
+        // The signaling client will automatically close, so we just need to clean up our resources
+        $('#stop-master-button').click();
+    });
+
     if (formValues.signalingReconnect && !master.channelHelper?.isIngestionEnabled()) {
         master.reopenChannelCallback = () => {
             console.log(`[${role}] Automatically reconnecting to signaling channel`);

--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -767,6 +767,13 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, rem
             console.error('[VIEWER] Signaling client error:', error);
         });
 
+        viewer.signalingClient.on('goAway', (message, senderClientId) => {
+            console.warn(`[VIEWER] Received GO_AWAY message from signaling service`);
+            console.log(`[VIEWER] Signaling service requested connection closure. Stopping viewer connection.`);
+            // The signaling client will automatically close, so we just need to clean up our resources
+            stopViewer();
+        });
+
         // Send any ICE candidates to the other peer
         viewer.peerConnection.addEventListener('icecandidate', ({ candidate }) => {
             if (candidate && candidate.candidate) {

--- a/src/SignalingClient.ts
+++ b/src/SignalingClient.ts
@@ -34,6 +34,7 @@ enum MessageType {
     SDP_OFFER = 'SDP_OFFER',
     ICE_CANDIDATE = 'ICE_CANDIDATE',
     STATUS_RESPONSE = 'STATUS_RESPONSE',
+    GO_AWAY = 'GO_AWAY',
 }
 
 enum ReadyState {
@@ -272,7 +273,7 @@ export class SignalingClient extends EventEmitter {
             // TODO: Consider how to make it easier for users to be aware of dropped messages.
         }
         const { messageType, senderClientId, statusResponse } = parsedEventData;
-        if (!parsedMessagePayload && !statusResponse) {
+        if (!parsedMessagePayload && !statusResponse && messageType !== MessageType.GO_AWAY) {
             // TODO: Consider how to make it easier for users to be aware of dropped messages.
             return;
         }
@@ -291,6 +292,11 @@ export class SignalingClient extends EventEmitter {
                 return;
             case MessageType.STATUS_RESPONSE:
                 this.emit('statusResponse', statusResponse);
+                return;
+            case MessageType.GO_AWAY:
+                this.emit('goAway', parsedMessagePayload, senderClientId);
+                // Automatically close the connection when receiving a GO_AWAY message
+                this.close();
                 return;
         }
     }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

**What was changed?**
- Added GO_AWAY message type to SignalingClient enum
- Added goAway event handling in SignalingClient with automatic connection closure
- Added goAway event handlers in master.js and viewer.js examples
- Added comprehensive test coverage for goAway message handling

**Why was it changed?**
- Enables graceful connection closure when the signaling service requests it
- Provides better error handling and user experience during service shutdowns or maintenance
- Allows the signaling service to proactively notify clients before closing connections

**How was it changed?**
- Extended MessageType enum with GO_AWAY constant
- Added message parsing and event emission for goAway messages
- Implemented automatic connection closure upon receiving goAway messages
- Added event listeners in example applications to handle graceful shutdown

**What testing was done for the changes?**
- Added unit tests for goAway message parsing with and without payload
- Verified automatic connection closure behavior
- Tested end2end in beta environment 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
