### PR TITLE
Dualstack endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ const kinesisVideoSignalingChannelsClient = new AWS.KinesisVideoSignalingChannel
 ```
 
 ##### Get ICE server configuration
-For best performance, we collect STUN and TURN ICE server configurations. The KVS STUN endpoint is always `stun:stun.kinesisvideo.${region}.amazonaws.com:443`.
+For best performance, we collect STUN and TURN ICE server configurations. The KVS STUN endpoint is always `stun:stun.kinesisvideo.${region}.amazonaws.com:443` for legacy-IPv4 endpoint mode and `stun:stun.kinesisvideo.${region}.api.aws:443` for dual-stack endpoint mode.
 To get TURN servers, the `GetIceServerConfig` API is used.
 ```js
 const getIceServerConfigResponse = await kinesisVideoSignalingChannelsClient

--- a/examples/app.css
+++ b/examples/app.css
@@ -31,3 +31,7 @@ pre .warn {
     height: 500px;
     overflow: auto;
 }
+
+#subheader {
+    margin-top: 30px;
+}

--- a/examples/app.js
+++ b/examples/app.js
@@ -269,7 +269,7 @@ $('#viewer-button').click(async () => {
             '[VIEWER]',
             formValues.clientId,
             formValues.logAwsSdkCalls ? console : undefined,
-            formValues.useDualStackEndpoints,);
+            formValues.useDualStackEndpoints);
         await channelHelper.determineMediaIngestionPath();
 
         if (channelHelper.isIngestionEnabled()) {

--- a/examples/app.js
+++ b/examples/app.js
@@ -93,6 +93,9 @@ function getTabScopedClientID() {
 }
 
 function getFormValues() {
+    const endpointInput = $('#endpoint').val();
+    const endpoint = endpointInput?.trim() || undefined;
+
     return {
         region: $('#region').val(),
         channelName: $('#channelName').val(),
@@ -111,7 +114,8 @@ function getFormValues() {
         forceSTUN: $('#forceSTUN').is(':checked'),
         forceTURN: $('#forceTURN').is(':checked'),
         accessKeyId: $('#accessKeyId').val(),
-        endpoint: $('#endpoint').val() || null,
+        useDualStackEndpoints: endpoint === undefined && $('#dual-stack').is(':checked'),
+        endpoint: endpoint,
         secretAccessKey: $('#secretAccessKey').val(),
         sessionToken: $('#sessionToken').val() || null,
         enableDQPmetrics: $('#enableDQPmetrics').is(':checked'),
@@ -264,7 +268,8 @@ $('#viewer-button').click(async () => {
             ChannelHelper.IngestionMode.DETERMINE_THROUGH_DESCRIBE,
             '[VIEWER]',
             formValues.clientId,
-            formValues.logAwsSdkCalls ? console : undefined);
+            formValues.logAwsSdkCalls ? console : undefined,
+            formValues.useDualStackEndpoints,);
         await channelHelper.determineMediaIngestionPath();
 
         if (channelHelper.isIngestionEnabled()) {
@@ -575,6 +580,8 @@ const fields = [
     {field: 'secretAccessKey', type: 'text'},
     {field: 'sessionToken', type: 'text'},
     {field: 'endpoint', type: 'text'},
+    {field: 'legacy', type: 'radio', name: 'endpoint-type'},
+    {field: 'dual-stack', type: 'radio', name: 'endpoint-type'},
     {field: 'sendVideo', type: 'checkbox'},
     {field: 'sendAudio', type: 'checkbox'},
     {field: 'streamName', type: 'text'},

--- a/examples/channelHelper.js
+++ b/examples/channelHelper.js
@@ -12,7 +12,7 @@ class ChannelHelper {
         DETERMINE_THROUGH_DESCRIBE: 2,
     };
 
-    constructor(channelName, clientArgs, endpoint, role, ingestionMode, loggingPrefix, clientId, logger) {
+    constructor(channelName, clientArgs, endpoint, role, ingestionMode, loggingPrefix, clientId, logger, useDualStackEndpoints) {
         this._channelName = channelName;
         this._clientArgs = clientArgs;
         this._role = role;
@@ -21,6 +21,7 @@ class ChannelHelper {
         this._loggingPrefix = loggingPrefix;
         this._clientId = clientId;
         this._logger = logger;
+        this._useDualStackEndpoints = useDualStackEndpoints;
     }
 
     // Must be called first
@@ -188,6 +189,7 @@ class ChannelHelper {
                 ...this._clientArgs,
                 logger: this._logger,
                 endpoint: this._endpoint,
+                useDualstackEndpoint: this._useDualStackEndpoints,
                 correctClockSkew: true,
             });
         }

--- a/examples/createSignalingChannel.js
+++ b/examples/createSignalingChannel.js
@@ -18,6 +18,7 @@ async function createSignalingChannel(formValues) {
             },
             endpoint: formValues.endpoint,
             logger: formValues.logAwsSdkCalls ? console : undefined,
+            useDualstackEndpoint: formValues.useDualStackEndpoints,
         });
 
         // Create signaling channel

--- a/examples/createStream.js
+++ b/examples/createStream.js
@@ -20,6 +20,7 @@ async function createStream(formValues) {
             region: formValues.region,
             endpoint: formValues.endpoint,
             logger: formValues.logAwsSdkCalls ? console : undefined,
+            useDualstackEndpoint: formValues.useDualStackEndpoints,
         });
 
         const createStreamResponse = await kinesisVideoClient

--- a/examples/describeMediaStorageConfiguration.js
+++ b/examples/describeMediaStorageConfiguration.js
@@ -19,6 +19,7 @@ async function describeMediaStorageConfiguration(formValues) {
             },
             endpoint: formValues.endpoint,
             logger: formValues.logAwsSdkCalls ? console : undefined,
+            useDualstackEndpoint: formValues.useDualStackEndpoints,
         });
 
         const mediaStorageConfiguration = await kinesisVideoClient.send(new AWS.KinesisVideo.DescribeMediaStorageConfigurationCommand({ ChannelName: formValues.channelName }));

--- a/examples/index.html
+++ b/examples/index.html
@@ -25,14 +25,13 @@
     <div class="row loader"></div>
     <div id="main" class="d-none">
         <form id="form" onsubmit="return false">
-            <h4>KVS Endpoint</h4>
             <div class="form-group has-validation" style="position: relative;">
                 <label for="region">Region</label>
                 <input type="text" class="form-control valid" id="region" placeholder="Region" value="us-west-2" autocomplete="off" required>
                 <datalist id="regionList"></datalist>
                 <div id="region-invalid-feedback" class="invalid-feedback"></div>
             </div>
-            <h4>AWS Credentials</h4>
+            <h4 id="subheader">AWS Credentials</h4>
             <div class="form-group">
                 <label for="accessKeyId">Access Key ID</label>
                 <input type="text" class="form-control" id="accessKeyId" placeholder="Access key id" required>
@@ -45,7 +44,7 @@
                 <label for="sessionToken">Session Token <small>(optional)</small></label>
                 <input type="password" class="form-control" id="sessionToken" placeholder="Session token">
             </div>
-            <h4>Signaling Channel</h4>
+            <h4 id="subheader">Signaling Channel</h4>
             <div>
                 <label for="channelName">Channel Name</label>
                 <div class="form-group input-group">
@@ -63,7 +62,7 @@
                     "><sup>&#9432;</sup></span>
                 <input type="text" class="form-control" id="clientId" placeholder="Client id">
             </div>
-            <h4>Tracks</h4>
+            <h4 id="subheader">Tracks</h4>
             <p><small>Control which media types are transmitted to the remote client. For WebRTC Ingestion and Storage master, both audio and video must be sent, and viewers cannot not send video and optional audio.</small></p>
             <div class="form-group">
                 <div class="form-check-inline">
@@ -83,7 +82,7 @@
                     "><sup>&#9432;</sup></span>
                 </div>
             </div>
-            <details id="webrtc-ingestion-and-storage-group"><summary class="h4">WebRTC Ingestion and Storage</summary>
+            <details id="webrtc-ingestion-and-storage-group"><summary class="h4" id="subheader">WebRTC Ingestion and Storage</summary>
             <div>
                 <p><small>Configure which stream to ingest and store media to. Call update media storage configuration with an empty Stream name to disable this feature.</small></p>
                 <div class="form-group input-group">
@@ -137,7 +136,7 @@
                 </div>
             </div>
             </details>
-            <h4>Video Resolution</h4>
+            <h4 id="subheader">Video Resolution</h4>
             <p><small>Set the desired video resolution and aspect ratio.</small></p>
             <div class="form-group">
                 <div class="form-check">
@@ -149,7 +148,7 @@
                     <label class="form-check-label" for="fullscreen">640x480 <small>(4:3 fullscreen)</small></label>
                 </div>
             </div>
-            <h4>NAT Traversal</h4>
+            <h4 id="subheader">NAT Traversal</h4>
             <p><small>Control settings for ICE candidate generation.</small>
             <span data-delay="{ &quot;hide&quot;: 1500 }" data-position="auto" tabindex="0" class="text-info" data-toggle="tooltip" data-html="true" title="
                     <p>Determines the types of <code>ICE candidates</code> that are generated.<br/><br/>STUN/TURN = host, server reflexive, and relay<br/>STUN only = server reflexive<br/>TURN only = relay<br/>Disabled = host</p>
@@ -183,7 +182,7 @@
                 "><sup>&#9432;</sup></span>
                 </div>
             </div>
-            <h4>Amazon KVS WebRTC DQP</h4>
+            <h4 id="subheader">Amazon KVS WebRTC DQP</h4>
             <div class="form-group">
                 <div class="form-check-inline">
                     <input class="form-check-input" type="checkbox" id="enableDQPmetrics" value="enableDQPmetrics">
@@ -195,7 +194,7 @@
                 </div>
             </div>
 
-            <h4>Amazon KVS WebRTC Profiling Timeline chart</h4>
+            <h4 id="subheader">Amazon KVS WebRTC Profiling Timeline chart</h4>
             <div class="form-group">
                 <div class="form-check-inline">
                     <input class="form-check-input" type="checkbox" id="enableProfileTimeline" value="enableProfileTimeline">
@@ -207,7 +206,7 @@
                 </div>
             </div>
 
-            <details><summary class="h4">Advanced</summary>
+            <details><summary class="h4" id="subheader">Advanced</summary>
                 <p class="mt-3"><small>Filter settings for which ICE candidates are sent to and received from the peer.</small></p>
                 <div class="container">
                     <div class="row">
@@ -317,6 +316,7 @@
                         </div>
                     </div>
                 </div>
+
                 <p class="mt-3"><small>TURN connection options</small><span data-delay="{ &quot;hide&quot;: 1500 }" data-position="auto" tabindex="0" class="text-info ml-1" data-toggle="tooltip" data-html="true" title="
                                 <p>Filter options for the URLs from the GetIceServerConfig API call.</p>"><sup>&#9432;</sup></span></p>
                 <div class="mt-3 mb-3 container">
@@ -338,14 +338,45 @@
                             <p>GetIceServerConfig returns two sets of TURN servers, only use one of the sets.</p>"><sup>&#9432;</sup></span></label>
                     </div>
                 </div>
+
+                <div class="d-flex align-items-center mt-3">
+                    <p class="mb-0">
+                        <small>KVS Endpoint Type</small>
+                    </p>
+
+                    <!-- Tooltip icon -->
+                    <span data-delay="{ &quot;hide&quot;: 1500 }"
+                        data-position="auto"
+                        tabindex="0"
+                        class="text-info ml-1"
+                        data-toggle="tooltip"
+                        data-html="true"
+                        title="<p>Use dual-stack KVS endpoints, else will use legacy IPv4-only endpoints. Dual-stack mode will also allow for IPv6 ICE candidates if supported by the browser and local network.</p>
+                        <a href=&quot;https://docs.aws.amazon.com/sdkref/latest/guide/feature-endpoints.html&quot;>Additional information</a>">
+                        <sup>&#9432;</sup>
+                    </span>
+                </div>
+
+                <div class="form-group">
+                    <div class="form-check">
+                        <input class="form-check-input" type="radio" name="endpoint-type" id="legacy" value="option1" checked>
+                        <label class="form-check-label" for="legacy">Legacy <small>"amazonaws.com"</small></label>
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input" type="radio" name="endpoint-type" id="dual-stack" value="option2">
+                        <label class="form-check-label" for="dual-stack">Dual-stack <small>"api.aws"</small></label>
+                    </div>
+                </div>
+                                    
                 <p class="mt-3"><small>Endpoint Override</small></p>
                 <div class="form-group">
                     <input type="text" class="form-control" id="endpoint" placeholder="Endpoint">
                 </div>
+
             </details>
 
             <hr>
-            <div>
+            <div style="margin-top: 30px;">
                 <button id="master-button" type="submit" class="btn btn-primary">Start Master</button>
                 <button id="viewer-button" type="submit" class="btn btn-primary">Start Viewer</button>
             </div>

--- a/examples/joinStorageSession.js
+++ b/examples/joinStorageSession.js
@@ -18,6 +18,7 @@ async function joinStorageSessionManually(formValues) {
                 sessionToken: formValues.sessionToken,
             },
             endpoint: formValues.endpoint,
+            useDualstackEndpoint: formValues.useDualStackEndpoints,
         });
 
         // Step 1: Obtain the ARN of the Signaling Channel

--- a/examples/joinStorageSessionAsViewer.js
+++ b/examples/joinStorageSessionAsViewer.js
@@ -18,6 +18,7 @@ async function joinStorageSessionAsViewerManually(formValues) {
                 sessionToken: formValues.sessionToken,
             },
             endpoint: formValues.endpoint,
+            useDualstackEndpoint: formValues.useDualStackEndpoints,
         });
 
         // Step 1: Obtain the ARN of the Signaling Channel

--- a/examples/listStorageChannels.js
+++ b/examples/listStorageChannels.js
@@ -19,6 +19,7 @@ async function listStorageChannels(formValues) {
             },
             endpoint: formValues.endpoint,
             logger: formValues.logAwsSdkCalls ? console : undefined,
+            useDualstackEndpoint: formValues.useDualStackEndpoints,
         });
 
         // Get all signaling channels

--- a/examples/master.js
+++ b/examples/master.js
@@ -86,6 +86,7 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
             `[${role}]`,
             role === 'VIEWER' ? formValues.clientId : undefined,
             formValues.logAwsSdkCalls ? console : undefined,
+            formValues.useDualStackEndpoints,
         );
 
         await master.channelHelper.init();
@@ -351,7 +352,11 @@ async function getIceServersWithCaching(formValues) {
 
     // Add the STUN server unless it is disabled
     if (!formValues.natTraversalDisabled && !formValues.forceTURN && formValues.sendSrflxCandidates) {
-        iceServers.push({ urls: `stun:stun.kinesisvideo.${formValues.region}.amazonaws.com:443` });
+        if (formValues.useDualStackEndpoints) {
+            iceServers.push({ urls: `stun:stun.kinesisvideo.${formValues.region}.api.aws:443` });
+        } else {
+            iceServers.push({ urls: `stun:stun.kinesisvideo.${formValues.region}.amazonaws.com:443` });
+        }
     }
 
     // Add the TURN servers unless it is disabled

--- a/examples/updateMediaStorageConfiguration.js
+++ b/examples/updateMediaStorageConfiguration.js
@@ -24,6 +24,7 @@ async function updateMediaStorageConfiguration(formValues) {
                 sessionToken: formValues.sessionToken,
             },
             endpoint: formValues.endpoint,
+            useDualstackEndpoint: formValues.useDualStackEndpoints,
         });
 
         if (formValues.streamName) {

--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -367,6 +367,7 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, rem
             },
             endpoint: formValues.endpoint,
             correctClockSkew: true,
+            useDualstackEndpoint: formValues.useDualStackEndpoints,
         });
 
         // Get signaling channel ARN
@@ -450,7 +451,11 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, rem
         const iceServers = [];
         // Don't add stun if user selects TURN only or NAT traversal disabled
         if (!formValues.natTraversalDisabled && !formValues.forceTURN && formValues.sendSrflxCandidates) {
-            iceServers.push({ urls: `stun:stun.kinesisvideo.${formValues.region}.amazonaws.com:443` });
+            if (formValues.useDualStackEndpoints) {
+                iceServers.push({ urls: `stun:stun.kinesisvideo.${formValues.region}.api.aws:443` });
+            } else {
+                iceServers.push({ urls: `stun:stun.kinesisvideo.${formValues.region}.amazonaws.com:443` });
+            }
         }
 
         // Don't add turn if user selects STUN only or NAT traversal disabled


### PR DESCRIPTION
*Issue #, if available:*
Prev PR: https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/pull/431

*Description of changes:*
- Added radio buttons to control the `useDualStackEndpoints` parameter of `AWS.KinesisVideo` client instances.
- Spaced out all the headings to not be so crammed.
- Added dual-stack STUN server url to be used when in dual-stack mode.

<img src="https://github.com/user-attachments/assets/42950e59-b343-4feb-a5ee-b7b3ea272208" width="400">







<br>
<br>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
