### PR TITLE
scoped permission to the minimum requirement

### DIFF
--- a/.github/workflows/develop-publish-gh-pages.yml
+++ b/.github/workflows/develop-publish-gh-pages.yml
@@ -4,6 +4,9 @@ on:
     push:
         branches:
             - develop
+permissions:
+  contents: write
+  pages: write
 jobs:
     publish-ubuntu-build:
         runs-on: ubuntu-latest


### PR DESCRIPTION
This PR updates GitHub Actions workflows to use minimal required permissions instead of the default elevated permissions.

Why This Matters
Following the principle of least privilege, workflows should only have the specific permissions they need to function.

Changes
This PR adds explicit permissions: blocks to workflows that currently rely on default permissions, scoping them down to only what's required for their operations.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
