### PR TITLE
Sample change: allow master ingest mode to send video-only

### DIFF
--- a/examples/master.js
+++ b/examples/master.js
@@ -92,8 +92,8 @@ async function startMaster(localView, remoteView, formValues, onStatsReport, onR
         await master.channelHelper.init();
 
         if (master.channelHelper.isIngestionEnabled()) {
-            if (role === 'MASTER' && (!formValues.sendAudio || !formValues.sendVideo)) {
-                console.error(`[MASTER] Both Send Video and Send Audio checkboxes need to be checked to ingest and store media.`);
+            if (role === 'MASTER' && !formValues.sendVideo) {
+                console.error(`[MASTER] Sending video is required to ingest and store media.`);
                 return;
             } else if (role === 'VIEWER' && formValues.sendVideo) {
                 console.warn(`[VIEWER] Not allowed to send video. Overriding to false!`);
@@ -231,7 +231,7 @@ registerMasterSignalingClientCallbacks = (signalingClient, formValues, onStatsRe
         if (master.channelHelper.isIngestionEnabled()) {
             const CHECK_INTERVAL_SECONDS = 5;
             const RETRY_TIMEOUT_SECONDS = 30;
-            
+
             for (let i = CHECK_INTERVAL_SECONDS; i <= RETRY_TIMEOUT_SECONDS; i += CHECK_INTERVAL_SECONDS) {
                 setTimeout(function () {
                     // check the state each 5 seconds


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*Description of changes:*
- Adjust requirement from "audio+video" to "video" requirement.
- This is to support video-only mode for WebRTC ingestion and storage (allowed to not send audio)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
