### PR TITLE
change from pull_request to pull_request_target

### DIFF
--- a/.github/workflows/retarget-dependabot-to-develop.yml
+++ b/.github/workflows/retarget-dependabot-to-develop.yml
@@ -1,7 +1,7 @@
 name: Retarget Dependabot PRs to develop
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - master
 


### PR DESCRIPTION
*Issue #, if available:*
- the `retarget-dependabot-to-develop.yml` workflow failing with GraphQL permission errors.

*Description of changes:*
- Changed `pull_request` to `pull_request_target` event trigger. When Dependabot opens a PR, the `pull_request` event runs with restricted token permissions, causing `gh pr edit` to fail. The `pull_request_target` event runs from the base repository context with full permissions, allowing the workflow to successfully retarget PRs from master to develop.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
