### PR TITLE
fix: add enableEarlyIceCandidateBuffering for media server ICE handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,10 +346,6 @@ Closes the active connection to the signaling service. Nothing will happen if th
 Emits any pending ICE candidates that arrived before the SDP offer/answer. Call this after `setRemoteDescription` completes when `enableEarlyIceCandidateBuffering` is enabled.
 * `clientId` {string} The client ID to drain candidates for. Required for 'MASTER' role. If omitted, drains for the default client.
 
-#### Method: `resetIceCandidateState([clientId])`
-Resets the ICE candidate queuing state for the given client. Call this before a retry/reconnect so that ICE candidates arriving before the new SDP are correctly queued instead of being emitted to nonexistent listeners.
-* `clientId` {string} The client ID to reset state for. If omitted, resets the default client.
-
 #### Method: `getPendingIceCandidates([clientId]) => object[]`
 Returns the pending ICE candidates for the given client. Useful for debugging to check if candidates are stuck in the queue.
 * `clientId` {string} The client ID to get pending candidates for. If omitted, returns candidates for the default client.

--- a/README.md
+++ b/README.md
@@ -271,7 +271,8 @@ This class is the main class for interfacing with the KVS signaling service. It 
   * `systemClockOffset` {number} Optional. Applies the given offset when setting the date in the SigV4 signature.
   See [systemClockOffset](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#systemClockOffset-property) and [correctClockSkew](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#correctClockSkew-property)
   properties of the AWS SDK.
-  * `enableEarlyIceCandidateBuffering` {boolean} Optional. Default: `false`. When `true`, ICE candidates that arrive before the SDP offer/answer are buffered and not automatically emitted. The consumer must call `drainPendingIceCandidates()` after `setRemoteDescription` completes to release them. Set to `true` when connecting to a media server where ICE candidates may arrive before the SDP.
+  * `enableEarlyIceCandidateBuffering` {boolean} Optional. Default: `false`. When `true`, ICE candidates that arrive before the SDP offer/answer are buffered and not automatically emitted. The consumer must call drainPendingIceCandidates() after connecting this client's ice candidate listener to release the early ice candidates.
+  * `logger` {SignalingClientLogger} Optional. Logger object for diagnostic logging. If provided, the SDK logs ICE candidate buffering, draining, and SDP events through this logger. If not provided, no logging occurs. Pass `console` to log to the browser console, or provide a custom object with `debug`, `log`, and `warn` methods.
 
 #### Event: `'open'`
 Emitted when the connection to the signaling service is open.

--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ This class is the main class for interfacing with the KVS signaling service. It 
   * `systemClockOffset` {number} Optional. Applies the given offset when setting the date in the SigV4 signature.
   See [systemClockOffset](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#systemClockOffset-property) and [correctClockSkew](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#correctClockSkew-property)
   properties of the AWS SDK.
+  * `enableEarlyIceCandidateBuffering` {boolean} Optional. Default: `false`. When `true`, ICE candidates that arrive before the SDP offer/answer are buffered and not automatically emitted. The consumer must call `drainPendingIceCandidates()` after `setRemoteDescription` completes to release them. Set to `true` when connecting to a media server where ICE candidates may arrive before the SDP.
 
 #### Event: `'open'`
 Emitted when the connection to the signaling service is open.
@@ -340,6 +341,23 @@ Closes the active connection to the signaling service. Nothing will happen if th
 * `iceCandidate` {[RTCIceCandidate](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate)} ICE candidate to send to the recipient client.
 * `recipientClientId` {string} The id of the client to send the ICE candidate to. If no id is provided, it will be sent to the master.
 * `correlationId` {string} A unique identifier for this message. If there was an error with this message, Signaling will send a failure StatusResponse with the same correlationId.
+
+#### Method: `drainPendingIceCandidates([clientId])`
+Emits any pending ICE candidates that arrived before the SDP offer/answer. Call this after `setRemoteDescription` completes when `enableEarlyIceCandidateBuffering` is enabled.
+* `clientId` {string} The client ID to drain candidates for. Required for 'MASTER' role. If omitted, drains for the default client.
+
+#### Method: `resetIceCandidateState([clientId])`
+Resets the ICE candidate queuing state for the given client. Call this before a retry/reconnect so that ICE candidates arriving before the new SDP are correctly queued instead of being emitted to nonexistent listeners.
+* `clientId` {string} The client ID to reset state for. If omitted, resets the default client.
+
+#### Method: `getPendingIceCandidates([clientId]) => object[]`
+Returns the pending ICE candidates for the given client. Useful for debugging to check if candidates are stuck in the queue.
+* `clientId` {string} The client ID to get pending candidates for. If omitted, returns candidates for the default client.
+* `return` {object[]} Array of pending ICE candidate objects.
+
+#### Method: `isEarlyIceCandidateBufferingEnabled() => boolean`
+Returns whether early ICE candidate buffering is enabled in the client configuration.
+* `return` {boolean} `true` if `enableEarlyIceCandidateBuffering` was set to `true` in the config.
 
 ### Interface: `RequestSigner`
 Interface for signing HTTP and WebSocket requests.

--- a/examples/answerer.js
+++ b/examples/answerer.js
@@ -40,6 +40,7 @@ class Answerer {
         inboundIceCandidateFilterFn = candidate => true,
         mediaStreamsUpdated = mediaStreams => {},
         dataChannelMessageReceived = (dataChannelMessage) => {},
+        enableEarlyIceCandidateBuffering = false,
     ) {
         this._configuration = rtcPeerConnectionConfiguration;
         this._mediaStream = localMediaStream;
@@ -53,6 +54,7 @@ class Answerer {
         this._inboundIceCandidateFilterFn = inboundIceCandidateFilterFn;
         this._onMediaStreamsUpdated = mediaStreamsUpdated;
         this._dataChannelMessageReceived = dataChannelMessageReceived;
+        this._enableEarlyIceCandidateBuffering = enableEarlyIceCandidateBuffering;
 
         this._dataChannel = null;
         this._peerConnection = null;
@@ -149,6 +151,12 @@ class Answerer {
         }
 
         await this._peerConnection.setRemoteDescription(this._offer);
+
+        // When early ICE candidate buffering is enabled (media server mode), manually drain
+        // any ICE candidates that arrived before the SDP offer.
+        if (this._enableEarlyIceCandidateBuffering) {
+            this._signalingClient.drainPendingIceCandidates(this._remoteClientId);
+        }
 
         const [videoCodecs, audioCodecs] = getCodecFilters();
         this._peerConnection.getTransceivers().map(async (transceiver) => {

--- a/examples/channelHelper.js
+++ b/examples/channelHelper.js
@@ -140,6 +140,7 @@ class ChannelHelper {
             role: this._role,
             clientId: this._clientId,
             enableEarlyIceCandidateBuffering: this.isIngestionEnabled(),
+            logger: console,
             requestSigner: {
                 // We override the default requestSigner to add timing information.
                 // Inside the function, `this` refers to the function itself,

--- a/examples/channelHelper.js
+++ b/examples/channelHelper.js
@@ -139,6 +139,7 @@ class ChannelHelper {
             channelEndpoint: this._endpoints['WSS'],
             role: this._role,
             clientId: this._clientId,
+            enableEarlyIceCandidateBuffering: this.isIngestionEnabled(),
             requestSigner: {
                 // We override the default requestSigner to add timing information.
                 // Inside the function, `this` refers to the function itself,

--- a/examples/master.js
+++ b/examples/master.js
@@ -203,7 +203,7 @@ registerMasterSignalingClientCallbacks = (signalingClient, formValues, onStatsRe
             iceCandidate => shouldAcceptCandidate(formValues, iceCandidate),
             mediaStreams => addViewerMediaStreamToMaster(remoteClientId, mediaStreams[0]),
             dataChannelMessage => onRemoteDataMessage(dataChannelMessage),
-            master.channelHelper.getSignalingClient().isEarlyIceCandidateBufferingEnabled(),
+            master.channelHelper.isIngestionEnabled(),
         );
 
         await answerer.init();
@@ -216,7 +216,6 @@ registerMasterSignalingClientCallbacks = (signalingClient, formValues, onStatsRe
             if (event.target.connectionState === 'connected') {
                 const pendingCandidates = signalingClient.getPendingIceCandidates(remoteClientId);
                 if (pendingCandidates.length > 0) {
-                    console.warn(`[${role}] Connection established but ${pendingCandidates.length} ICE candidate(s) are STILL stuck in the queue and were never used. drainPendingIceCandidates() was never called.`);
                     pendingCandidates.forEach((candidate, i) => {
                         console.warn(`[${role}] Stuck candidate ${i + 1}:`, JSON.stringify(candidate));
                     });

--- a/examples/master.js
+++ b/examples/master.js
@@ -319,6 +319,7 @@ function onPeerConnectionFailed(remoteClientId, printLostConnectionLog = true) {
         console.warn(`[${role}] Reconnecting...`);
 
         master.sdpOfferReceived = false;
+        master.channelHelper.getSignalingClient().resetIceCandidateState();
         if (!master.websocketOpened) {
             const channelHelper = master.channelHelper;
             if (channelHelper) {

--- a/examples/master.js
+++ b/examples/master.js
@@ -203,6 +203,7 @@ registerMasterSignalingClientCallbacks = (signalingClient, formValues, onStatsRe
             iceCandidate => shouldAcceptCandidate(formValues, iceCandidate),
             mediaStreams => addViewerMediaStreamToMaster(remoteClientId, mediaStreams[0]),
             dataChannelMessage => onRemoteDataMessage(dataChannelMessage),
+            master.channelHelper.getSignalingClient().isEarlyIceCandidateBufferingEnabled(),
         );
 
         await answerer.init();
@@ -211,6 +212,16 @@ registerMasterSignalingClientCallbacks = (signalingClient, formValues, onStatsRe
 
         answerer.getPeerConnection().addEventListener('connectionstatechange', async event => {
             printPeerConnectionStateInfo(event, `[${role}]`, remoteClientId);
+
+            if (event.target.connectionState === 'connected') {
+                const pendingCandidates = signalingClient.getPendingIceCandidates(remoteClientId);
+                if (pendingCandidates.length > 0) {
+                    console.warn(`[${role}] Connection established but ${pendingCandidates.length} ICE candidate(s) are STILL stuck in the queue and were never used. drainPendingIceCandidates() was never called.`);
+                    pendingCandidates.forEach((candidate, i) => {
+                        console.warn(`[${role}] Stuck candidate ${i + 1}:`, JSON.stringify(candidate));
+                    });
+                }
+            }
 
             if (master.channelHelper.isIngestionEnabled() && event.target.connectionState === 'connected') {
                 if (role === 'MASTER') {

--- a/examples/master.js
+++ b/examples/master.js
@@ -318,7 +318,6 @@ function onPeerConnectionFailed(remoteClientId, printLostConnectionLog = true) {
         console.warn(`[${role}] Reconnecting...`);
 
         master.sdpOfferReceived = false;
-        master.channelHelper.getSignalingClient().resetIceCandidateState();
         if (!master.websocketOpened) {
             const channelHelper = master.channelHelper;
             if (channelHelper) {

--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -532,6 +532,7 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, rem
                 },
             },
             systemClockOffset: kinesisVideoClient.config.systemClockOffset,
+            logger: console,
         });
 
         const resolution = formValues.widescreen

--- a/src/SignalingClient.spec.ts
+++ b/src/SignalingClient.spec.ts
@@ -571,6 +571,23 @@ describe('SignalingClient', () => {
                 client.open();
             });
 
+            it('should warn when ICE candidates are emitted with no iceCandidate listener', (done) => {
+                const client = new SignalingClient(config as SignalingClientConfig);
+                const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+                client.on('open', () => {
+                    // Queue a candidate before SDP
+                    MockWebSocket.instance.emit('message', { data: ICE_CANDIDATE_MASTER_MESSAGE });
+                    // Receive SDP to trigger auto-drain with no iceCandidate listener
+                    MockWebSocket.instance.emit('message', { data: SDP_ANSWER_MASTER_MESSAGE });
+                    expect(warnSpy).toHaveBeenCalledWith(
+                        '[SignalingClient] No iceCandidate listener attached. ICE candidate was emitted but not handled.',
+                    );
+                    warnSpy.mockRestore();
+                    done();
+                });
+                client.open();
+            });
+
             it('should parse iceCandidate messages from the master', (done) => {
                 const client = new SignalingClient(config as SignalingClientConfig);
                 client.on('iceCandidate', (iceCandidate, senderClientId) => {

--- a/src/SignalingClient.spec.ts
+++ b/src/SignalingClient.spec.ts
@@ -700,28 +700,6 @@ describe('SignalingClient', () => {
                 client.open();
             });
         });
-
-        describe('resetIceCandidateState', () => {
-            it('should re-queue ICE candidates after reset', (done) => {
-                const client = new SignalingClient(config as SignalingClientConfig);
-                client.on('open', () => {
-                    // Receive SDP answer to set hasReceivedRemoteSDPByClientId to true
-                    MockWebSocket.instance.emit('message', { data: SDP_ANSWER_MASTER_MESSAGE });
-
-                    // Reset state to simulate retry
-                    client.resetIceCandidateState();
-
-                    // ICE candidate should now be queued, not emitted
-                    client.on('iceCandidate', () => {
-                        done(new Error('Should not have emitted iceCandidate after reset'));
-                    });
-                    MockWebSocket.instance.emit('message', { data: ICE_CANDIDATE_MASTER_MESSAGE });
-                    expect(client.getPendingIceCandidates().length).toEqual(1);
-                    done();
-                });
-                client.open();
-            });
-        });
     });
 
     describe('outsideBrowser', () => {

--- a/src/SignalingClient.spec.ts
+++ b/src/SignalingClient.spec.ts
@@ -618,6 +618,95 @@ describe('SignalingClient', () => {
                 client.open();
             });
         });
+
+        describe('getPendingIceCandidates', () => {
+            it('should return empty array when no candidates are pending', () => {
+                const client = new SignalingClient(config as SignalingClientConfig);
+                expect(client.getPendingIceCandidates()).toEqual([]);
+            });
+
+            it('should return pending candidates that arrived before SDP', (done) => {
+                const client = new SignalingClient(config as SignalingClientConfig);
+                client.on('open', () => {
+                    MockWebSocket.instance.emit('message', { data: ICE_CANDIDATE_MASTER_MESSAGE });
+                    expect(client.getPendingIceCandidates().length).toEqual(1);
+                    done();
+                });
+                client.open();
+            });
+        });
+
+        describe('isEarlyIceCandidateBufferingEnabled', () => {
+            it('should return false by default', () => {
+                const client = new SignalingClient(config as SignalingClientConfig);
+                expect(client.isEarlyIceCandidateBufferingEnabled()).toBe(false);
+            });
+
+            it('should return true when enabled in config', () => {
+                const client = new SignalingClient({
+                    ...config,
+                    enableEarlyIceCandidateBuffering: true,
+                } as SignalingClientConfig);
+                expect(client.isEarlyIceCandidateBufferingEnabled()).toBe(true);
+            });
+
+            it('should not auto-drain pending ICE candidates after SDP offer when enabled', (done) => {
+                const client = new SignalingClient({
+                    ...config,
+                    enableEarlyIceCandidateBuffering: true,
+                } as SignalingClientConfig);
+                client.on('iceCandidate', () => {
+                    done(new Error('Should not have emitted iceCandidate'));
+                });
+                client.on('open', () => {
+                    MockWebSocket.instance.emit('message', { data: ICE_CANDIDATE_MASTER_MESSAGE });
+                    MockWebSocket.instance.emit('message', { data: SDP_OFFER_MASTER_MESSAGE });
+                    // With buffering enabled, candidates should still be pending
+                    expect(client.getPendingIceCandidates().length).toEqual(1);
+                    done();
+                });
+                client.open();
+            });
+
+            it('should not auto-drain pending ICE candidates after SDP answer when enabled', (done) => {
+                const client = new SignalingClient({
+                    ...config,
+                    enableEarlyIceCandidateBuffering: true,
+                } as SignalingClientConfig);
+                client.on('iceCandidate', () => {
+                    done(new Error('Should not have emitted iceCandidate'));
+                });
+                client.on('open', () => {
+                    MockWebSocket.instance.emit('message', { data: ICE_CANDIDATE_MASTER_MESSAGE });
+                    MockWebSocket.instance.emit('message', { data: SDP_ANSWER_MASTER_MESSAGE });
+                    expect(client.getPendingIceCandidates().length).toEqual(1);
+                    done();
+                });
+                client.open();
+            });
+        });
+
+        describe('resetIceCandidateState', () => {
+            it('should re-queue ICE candidates after reset', (done) => {
+                const client = new SignalingClient(config as SignalingClientConfig);
+                client.on('open', () => {
+                    // Receive SDP answer to set hasReceivedRemoteSDPByClientId to true
+                    MockWebSocket.instance.emit('message', { data: SDP_ANSWER_MASTER_MESSAGE });
+
+                    // Reset state to simulate retry
+                    client.resetIceCandidateState();
+
+                    // ICE candidate should now be queued, not emitted
+                    client.on('iceCandidate', () => {
+                        done(new Error('Should not have emitted iceCandidate after reset'));
+                    });
+                    MockWebSocket.instance.emit('message', { data: ICE_CANDIDATE_MASTER_MESSAGE });
+                    expect(client.getPendingIceCandidates().length).toEqual(1);
+                    done();
+                });
+                client.open();
+            });
+        });
     });
 
     describe('outsideBrowser', () => {

--- a/src/SignalingClient.spec.ts
+++ b/src/SignalingClient.spec.ts
@@ -617,7 +617,11 @@ describe('SignalingClient', () => {
                     MockWebSocket.instance.emit('message', { data: ICE_CANDIDATE_MASTER_MESSAGE });
                     // Receive SDP to trigger auto-drain with no iceCandidate listener
                     MockWebSocket.instance.emit('message', { data: SDP_ANSWER_MASTER_MESSAGE });
-                    expect(warnSpy).toHaveBeenCalledWith('[SignalingClient]', 'No iceCandidate listener attached. ICE candidate was emitted but not handled.');
+                    expect(warnSpy).toHaveBeenCalledWith(
+                        '[SignalingClient]',
+                        'No iceCandidate listener attached. ICE candidate was emitted but not handled.',
+                        expect.any(String),
+                    );
                     done();
                 });
                 client.open();

--- a/src/SignalingClient.spec.ts
+++ b/src/SignalingClient.spec.ts
@@ -127,6 +127,7 @@ describe('SignalingClient', () => {
             requestSigner: {
                 getSignedURL: signer,
             },
+            logger: { debug: jest.fn(), log: jest.fn(), warn: jest.fn() },
         };
     });
 
@@ -464,6 +465,20 @@ describe('SignalingClient', () => {
                 client.open();
             });
 
+            it('should parse sdpOffer messages without a logger configured', (done) => {
+                const noLoggerConfig = { ...config };
+                delete noLoggerConfig.logger;
+                const client = new SignalingClient(noLoggerConfig as SignalingClientConfig);
+                client.once('sdpOffer', (sdpOffer) => {
+                    expect(sdpOffer).toEqual(SDP_OFFER_OBJECT);
+                    done();
+                });
+                client.once('open', () => {
+                    MockWebSocket.instance.emit('message', { data: SDP_OFFER_MASTER_MESSAGE });
+                });
+                client.open();
+            });
+
             it('should parse sdpOffer messages from the viewer', (done) => {
                 config.role = Role.MASTER;
                 delete config.clientId;
@@ -571,16 +586,50 @@ describe('SignalingClient', () => {
                 client.open();
             });
 
+            it('should handle ICE candidates without a logger configured', (done) => {
+                const noLoggerConfig = { ...config };
+                delete noLoggerConfig.logger;
+                const client = new SignalingClient(noLoggerConfig as SignalingClientConfig);
+                let count = 0;
+                client.on('iceCandidate', (iceCandidate) => {
+                    expect(iceCandidate).toEqual(ICE_CANDIDATE_OBJECT);
+                    if (++count === 2) {
+                        done();
+                    }
+                });
+                client.on('open', () => {
+                    // Candidate before SDP - buffered (no logger)
+                    MockWebSocket.instance.emit('message', { data: ICE_CANDIDATE_MASTER_MESSAGE });
+                    // SDP arrives - triggers drain (no logger)
+                    MockWebSocket.instance.emit('message', { data: SDP_ANSWER_MASTER_MESSAGE });
+                    // Candidate after SDP - emitted immediately (no logger)
+                    MockWebSocket.instance.emit('message', { data: ICE_CANDIDATE_MASTER_MESSAGE });
+                });
+                client.open();
+            });
+
             it('should warn when ICE candidates are emitted with no iceCandidate listener', (done) => {
-                const client = new SignalingClient(config as SignalingClientConfig);
-                const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+                const warnSpy = jest.fn();
+                const loggerConfig = { ...config, logger: { debug: jest.fn(), log: jest.fn(), warn: warnSpy } };
+                const client = new SignalingClient(loggerConfig as SignalingClientConfig);
                 client.on('open', () => {
                     // Queue a candidate before SDP
                     MockWebSocket.instance.emit('message', { data: ICE_CANDIDATE_MASTER_MESSAGE });
                     // Receive SDP to trigger auto-drain with no iceCandidate listener
                     MockWebSocket.instance.emit('message', { data: SDP_ANSWER_MASTER_MESSAGE });
                     expect(warnSpy).toHaveBeenCalledWith('[SignalingClient]', 'No iceCandidate listener attached. ICE candidate was emitted but not handled.');
-                    warnSpy.mockRestore();
+                    done();
+                });
+                client.open();
+            });
+
+            it('should not throw when ICE candidates are emitted with no listener and no logger', (done) => {
+                const noLoggerConfig = { ...config };
+                delete noLoggerConfig.logger;
+                const client = new SignalingClient(noLoggerConfig as SignalingClientConfig);
+                client.on('open', () => {
+                    MockWebSocket.instance.emit('message', { data: ICE_CANDIDATE_MASTER_MESSAGE });
+                    MockWebSocket.instance.emit('message', { data: SDP_ANSWER_MASTER_MESSAGE });
                     done();
                 });
                 client.open();

--- a/src/SignalingClient.spec.ts
+++ b/src/SignalingClient.spec.ts
@@ -579,9 +579,7 @@ describe('SignalingClient', () => {
                     MockWebSocket.instance.emit('message', { data: ICE_CANDIDATE_MASTER_MESSAGE });
                     // Receive SDP to trigger auto-drain with no iceCandidate listener
                     MockWebSocket.instance.emit('message', { data: SDP_ANSWER_MASTER_MESSAGE });
-                    expect(warnSpy).toHaveBeenCalledWith(
-                        '[SignalingClient] No iceCandidate listener attached. ICE candidate was emitted but not handled.',
-                    );
+                    expect(warnSpy).toHaveBeenCalledWith('[SignalingClient]', 'No iceCandidate listener attached. ICE candidate was emitted but not handled.');
                     warnSpy.mockRestore();
                     done();
                 });

--- a/src/SignalingClient.spec.ts
+++ b/src/SignalingClient.spec.ts
@@ -479,7 +479,7 @@ describe('SignalingClient', () => {
                 client.open();
             });
 
-            it('should parse sdpOffer messages from the master and release pending ICE candidates', (done) => {
+            it('should parse sdpOffer messages from the master and release pending ICE candidates when drained', (done) => {
                 const client = new SignalingClient(config as SignalingClientConfig);
                 let count = 0;
                 client.once('sdpOffer', (sdpOffer, senderClientId) => {
@@ -493,6 +493,7 @@ describe('SignalingClient', () => {
                             client.removeAllListeners();
                         }
                     });
+                    client.drainPendingIceCandidates(senderClientId);
                 });
                 client.once('open', () => {
                     MockWebSocket.instance.emit('message', { data: ICE_CANDIDATE_MASTER_MESSAGE });
@@ -532,7 +533,7 @@ describe('SignalingClient', () => {
                 client.open();
             });
 
-            it('should parse sdpAnswer messages from the master and release pending ICE candidates', (done) => {
+            it('should parse sdpAnswer messages from the master and release pending ICE candidates when drained', (done) => {
                 const client = new SignalingClient(config as SignalingClientConfig);
                 client.once('sdpAnswer', (sdpAnswer, senderClientId) => {
                     expect(sdpAnswer).toEqual(SDP_ANSWER_OBJECT);
@@ -546,6 +547,7 @@ describe('SignalingClient', () => {
                             client.removeAllListeners();
                         }
                     });
+                    client.drainPendingIceCandidates(senderClientId);
                 });
                 client.on('open', () => {
                     MockWebSocket.instance.emit('message', { data: ICE_CANDIDATE_MASTER_MESSAGE });
@@ -557,6 +559,18 @@ describe('SignalingClient', () => {
         });
 
         describe('iceCandidate', () => {
+            it('should not emit any candidates when drainPendingIceCandidates is called with no pending candidates', (done) => {
+                const client = new SignalingClient(config as SignalingClientConfig);
+                client.on('iceCandidate', () => {
+                    done(new Error('Should not have emitted iceCandidate'));
+                });
+                client.on('open', () => {
+                    client.drainPendingIceCandidates();
+                    done();
+                });
+                client.open();
+            });
+
             it('should parse iceCandidate messages from the master', (done) => {
                 const client = new SignalingClient(config as SignalingClientConfig);
                 client.on('iceCandidate', (iceCandidate, senderClientId) => {

--- a/src/SignalingClient.ts
+++ b/src/SignalingClient.ts
@@ -79,6 +79,7 @@ export interface StatusResponse {
  */
 export class SignalingClient extends EventEmitter {
     private static DEFAULT_CLIENT_ID = 'MASTER';
+    private static LOG_PREFIX = '[SignalingClient]';
 
     private websocket: WebSocket = null;
     private readyState = ReadyState.CLOSED;
@@ -261,7 +262,7 @@ export class SignalingClient extends EventEmitter {
         const clientIdKey = clientId || SignalingClient.DEFAULT_CLIENT_ID;
         delete this.hasReceivedRemoteSDPByClientId[clientIdKey];
         delete this.pendingIceCandidatesByClientId[clientIdKey];
-        console.log('[SignalingClient] ICE candidate state reset for', clientIdKey);
+        console.debug(SignalingClient.LOG_PREFIX, 'ICE candidate state reset for', clientIdKey);
     }
 
     /**
@@ -336,8 +337,9 @@ export class SignalingClient extends EventEmitter {
         switch (messageType) {
             case MessageType.SDP_OFFER:
                 this.hasReceivedRemoteSDPByClientId[senderClientId || SignalingClient.DEFAULT_CLIENT_ID] = true;
-                console.log(
-                    '[SignalingClient] SDP_OFFER received. Pending ICE candidates for',
+                console.debug(
+                    SignalingClient.LOG_PREFIX,
+                    'SDP_OFFER received. Pending ICE candidates for',
                     senderClientId || SignalingClient.DEFAULT_CLIENT_ID,
                     ':',
                     (this.pendingIceCandidatesByClientId[senderClientId || SignalingClient.DEFAULT_CLIENT_ID] || []).length,
@@ -349,8 +351,9 @@ export class SignalingClient extends EventEmitter {
                 return;
             case MessageType.SDP_ANSWER:
                 this.hasReceivedRemoteSDPByClientId[senderClientId || SignalingClient.DEFAULT_CLIENT_ID] = true;
-                console.log(
-                    '[SignalingClient] SDP_ANSWER received. Pending ICE candidates for',
+                console.debug(
+                    SignalingClient.LOG_PREFIX,
+                    'SDP_ANSWER received. Pending ICE candidates for',
                     senderClientId || SignalingClient.DEFAULT_CLIENT_ID,
                     ':',
                     (this.pendingIceCandidatesByClientId[senderClientId || SignalingClient.DEFAULT_CLIENT_ID] || []).length,
@@ -400,7 +403,7 @@ export class SignalingClient extends EventEmitter {
     private emitOrQueueIceCandidate(iceCandidate: object, clientId?: string): void {
         const clientIdKey = clientId || SignalingClient.DEFAULT_CLIENT_ID;
         if (this.hasReceivedRemoteSDPByClientId[clientIdKey]) {
-            console.debug('[SignalingClient] ICE candidate arrived AFTER SDP for', clientIdKey, '- emitting immediately');
+            console.debug(SignalingClient.LOG_PREFIX, 'ICE candidate arrived AFTER SDP for', clientIdKey, '- emitting immediately');
             this.emit('iceCandidate', iceCandidate, clientId);
         } else {
             if (!this.pendingIceCandidatesByClientId[clientIdKey]) {
@@ -408,7 +411,8 @@ export class SignalingClient extends EventEmitter {
             }
             this.pendingIceCandidatesByClientId[clientIdKey].push(iceCandidate);
             console.debug(
-                '[SignalingClient] ICE candidate arrived before SDP for',
+                SignalingClient.LOG_PREFIX,
+                'ICE candidate arrived before SDP for',
                 clientIdKey,
                 '- buffered. Pending count:',
                 this.pendingIceCandidatesByClientId[clientIdKey].length,
@@ -428,12 +432,12 @@ export class SignalingClient extends EventEmitter {
         if (!pendingIceCandidates) {
             return;
         }
-        console.log('[SignalingClient] DRAINING', pendingIceCandidates.length, 'pending ICE candidates for', clientIdKey);
+        console.debug(SignalingClient.LOG_PREFIX, 'DRAINING', pendingIceCandidates.length, 'pending ICE candidates for', clientIdKey);
         delete this.pendingIceCandidatesByClientId[clientIdKey];
         pendingIceCandidates.forEach((iceCandidate) => {
             const hadListeners = this.emit('iceCandidate', iceCandidate, clientId);
             if (!hadListeners) {
-                console.warn('[SignalingClient] No iceCandidate listener attached. ICE candidate was emitted but not handled.');
+                console.warn(SignalingClient.LOG_PREFIX, 'No iceCandidate listener attached. ICE candidate was emitted but not handled.');
             }
         });
     }

--- a/src/SignalingClient.ts
+++ b/src/SignalingClient.ts
@@ -251,6 +251,20 @@ export class SignalingClient extends EventEmitter {
     }
 
     /**
+     * Resets the ICE candidate queuing state for the given client.
+     * Call this before a retry/reconnect so that ICE candidates arriving before the new SDP
+     * are correctly queued instead of being emitted to nonexistent listeners.
+     *
+     * @param {string} [clientId] - The client ID to reset state for. If omitted, resets the default client.
+     */
+    public resetIceCandidateState(clientId?: string): void {
+        const clientIdKey = clientId || SignalingClient.DEFAULT_CLIENT_ID;
+        delete this.hasReceivedRemoteSDPByClientId[clientIdKey];
+        delete this.pendingIceCandidatesByClientId[clientIdKey];
+        console.log('[SignalingClient] ICE candidate state reset for', clientIdKey);
+    }
+
+    /**
      * Validates the WebSocket connection is open and that the recipient client id is present if sending as the 'MASTER'. Encodes the given message payload
      * and sends the message to the signaling service.
      */

--- a/src/SignalingClient.ts
+++ b/src/SignalingClient.ts
@@ -39,6 +39,20 @@ export interface SignalingClientConfig {
      * before the SDP and the consumer needs explicit control over when they are processed.
      */
     enableEarlyIceCandidateBuffering?: boolean;
+    /**
+     * Optional logger object for diagnostic logging. If provided, the SDK will log ICE candidate
+     * buffering, draining, and SDP events through this logger. If not provided, no logging occurs.
+     *
+     * Pass `console` to log to the browser console, or provide a custom logger with
+     * `debug`, `log`, and `warn` methods.
+     */
+    logger?: SignalingClientLogger;
+}
+
+export interface SignalingClientLogger {
+    debug(...data: unknown[]): void;
+    log(...data: unknown[]): void;
+    warn(...data: unknown[]): void;
 }
 
 enum MessageType {
@@ -88,6 +102,7 @@ export class SignalingClient extends EventEmitter {
     private readonly pendingIceCandidatesByClientId: { [clientId: string]: object[] } = {};
     private readonly hasReceivedRemoteSDPByClientId: { [clientId: string]: boolean } = {};
     private readonly dateProvider: DateProvider;
+    private readonly logger?: SignalingClientLogger;
 
     /**
      * Creates a new SignalingClient. The connection with the signaling service must be opened with the 'open' method.
@@ -119,6 +134,7 @@ export class SignalingClient extends EventEmitter {
         }
 
         this.dateProvider = new DateProvider(config.systemClockOffset || 0);
+        this.logger = config.logger;
 
         // Bind event handlers
         this.onOpen = this.onOpen.bind(this);
@@ -323,7 +339,7 @@ export class SignalingClient extends EventEmitter {
         switch (messageType) {
             case MessageType.SDP_OFFER:
                 this.hasReceivedRemoteSDPByClientId[senderClientId || SignalingClient.DEFAULT_CLIENT_ID] = true;
-                console.debug(
+                this.logger?.debug(
                     SignalingClient.LOG_PREFIX,
                     'SDP_OFFER received. Pending ICE candidates for',
                     senderClientId || SignalingClient.DEFAULT_CLIENT_ID,
@@ -337,7 +353,7 @@ export class SignalingClient extends EventEmitter {
                 return;
             case MessageType.SDP_ANSWER:
                 this.hasReceivedRemoteSDPByClientId[senderClientId || SignalingClient.DEFAULT_CLIENT_ID] = true;
-                console.debug(
+                this.logger?.debug(
                     SignalingClient.LOG_PREFIX,
                     'SDP_ANSWER received. Pending ICE candidates for',
                     senderClientId || SignalingClient.DEFAULT_CLIENT_ID,
@@ -389,14 +405,14 @@ export class SignalingClient extends EventEmitter {
     private emitOrQueueIceCandidate(iceCandidate: object, clientId?: string): void {
         const clientIdKey = clientId || SignalingClient.DEFAULT_CLIENT_ID;
         if (this.hasReceivedRemoteSDPByClientId[clientIdKey]) {
-            console.debug(SignalingClient.LOG_PREFIX, 'ICE candidate arrived AFTER SDP for', clientIdKey, '- emitting immediately');
+            this.logger?.debug(SignalingClient.LOG_PREFIX, 'ICE candidate arrived AFTER SDP for', clientIdKey, '- emitting immediately');
             this.emit('iceCandidate', iceCandidate, clientId);
         } else {
             if (!this.pendingIceCandidatesByClientId[clientIdKey]) {
                 this.pendingIceCandidatesByClientId[clientIdKey] = [];
             }
             this.pendingIceCandidatesByClientId[clientIdKey].push(iceCandidate);
-            console.debug(
+            this.logger?.debug(
                 SignalingClient.LOG_PREFIX,
                 'ICE candidate arrived before SDP for',
                 clientIdKey,
@@ -418,12 +434,12 @@ export class SignalingClient extends EventEmitter {
         if (!pendingIceCandidates) {
             return;
         }
-        console.debug(SignalingClient.LOG_PREFIX, 'DRAINING', pendingIceCandidates.length, 'pending ICE candidates for', clientIdKey);
+        this.logger?.debug(SignalingClient.LOG_PREFIX, 'DRAINING', pendingIceCandidates.length, 'pending ICE candidates for', clientIdKey);
         delete this.pendingIceCandidatesByClientId[clientIdKey];
         pendingIceCandidates.forEach((iceCandidate) => {
             const hadListeners = this.emit('iceCandidate', iceCandidate, clientId);
             if (!hadListeners) {
-                console.warn(SignalingClient.LOG_PREFIX, 'No iceCandidate listener attached. ICE candidate was emitted but not handled.');
+                this.logger?.warn(SignalingClient.LOG_PREFIX, 'No iceCandidate listener attached. ICE candidate was emitted but not handled.');
             }
         });
     }

--- a/src/SignalingClient.ts
+++ b/src/SignalingClient.ts
@@ -221,9 +221,9 @@ export class SignalingClient extends EventEmitter {
     }
 
     /**
-     * Emits any pending ICE candidates for the given client. Call this after processing the remote SDP
-     * (e.g., after `setRemoteDescription` completes) to ensure ICE candidates are only emitted when the
-     * peer connection is ready to handle them.
+     * Emits any pending ICE candidates for the given client. Call this after attaching the
+     * `iceCandidate` event listener to ensure ICE candidates are only emitted when
+     * the consumer is ready to handle them.
      *
      * When using a media server, ICE candidates may arrive before or immediately after the SDP answer.
      * This method gives the consumer explicit control over when those queued candidates are released.
@@ -400,14 +400,14 @@ export class SignalingClient extends EventEmitter {
     private emitOrQueueIceCandidate(iceCandidate: object, clientId?: string): void {
         const clientIdKey = clientId || SignalingClient.DEFAULT_CLIENT_ID;
         if (this.hasReceivedRemoteSDPByClientId[clientIdKey]) {
-            console.log('[SignalingClient] ICE candidate arrived AFTER SDP for', clientIdKey, '- emitting immediately');
+            console.debug('[SignalingClient] ICE candidate arrived AFTER SDP for', clientIdKey, '- emitting immediately');
             this.emit('iceCandidate', iceCandidate, clientId);
         } else {
             if (!this.pendingIceCandidatesByClientId[clientIdKey]) {
                 this.pendingIceCandidatesByClientId[clientIdKey] = [];
             }
             this.pendingIceCandidatesByClientId[clientIdKey].push(iceCandidate);
-            console.log(
+            console.debug(
                 '[SignalingClient] ICE candidate arrived before SDP for',
                 clientIdKey,
                 '- buffered. Pending count:',
@@ -431,7 +431,10 @@ export class SignalingClient extends EventEmitter {
         console.log('[SignalingClient] DRAINING', pendingIceCandidates.length, 'pending ICE candidates for', clientIdKey);
         delete this.pendingIceCandidatesByClientId[clientIdKey];
         pendingIceCandidates.forEach((iceCandidate) => {
-            this.emit('iceCandidate', iceCandidate, clientId);
+            const hadListeners = this.emit('iceCandidate', iceCandidate, clientId);
+            if (!hadListeners) {
+                console.warn('[SignalingClient] No iceCandidate listener attached. ICE candidate was emitted but not handled.');
+            }
         });
     }
 

--- a/src/SignalingClient.ts
+++ b/src/SignalingClient.ts
@@ -347,7 +347,7 @@ export class SignalingClient extends EventEmitter {
                     (this.pendingIceCandidatesByClientId[senderClientId || SignalingClient.DEFAULT_CLIENT_ID] || []).length,
                 );
                 this.emit('sdpOffer', parsedMessagePayload, senderClientId);
-                if (!this.config.enableEarlyIceCandidateBuffering) {
+                if (!this.isEarlyIceCandidateBufferingEnabled()) {
                     this.emitPendingIceCandidates(senderClientId);
                 }
                 return;
@@ -361,7 +361,7 @@ export class SignalingClient extends EventEmitter {
                     (this.pendingIceCandidatesByClientId[senderClientId || SignalingClient.DEFAULT_CLIENT_ID] || []).length,
                 );
                 this.emit('sdpAnswer', parsedMessagePayload, senderClientId);
-                if (!this.config.enableEarlyIceCandidateBuffering) {
+                if (!this.isEarlyIceCandidateBufferingEnabled()) {
                     this.emitPendingIceCandidates(senderClientId);
                 }
                 return;

--- a/src/SignalingClient.ts
+++ b/src/SignalingClient.ts
@@ -336,8 +336,12 @@ export class SignalingClient extends EventEmitter {
         switch (messageType) {
             case MessageType.SDP_OFFER:
                 this.hasReceivedRemoteSDPByClientId[senderClientId || SignalingClient.DEFAULT_CLIENT_ID] = true;
-                console.log('[SignalingClient] SDP_OFFER received. Pending ICE candidates for', senderClientId || SignalingClient.DEFAULT_CLIENT_ID, ':',
-                    (this.pendingIceCandidatesByClientId[senderClientId || SignalingClient.DEFAULT_CLIENT_ID] || []).length);
+                console.log(
+                    '[SignalingClient] SDP_OFFER received. Pending ICE candidates for',
+                    senderClientId || SignalingClient.DEFAULT_CLIENT_ID,
+                    ':',
+                    (this.pendingIceCandidatesByClientId[senderClientId || SignalingClient.DEFAULT_CLIENT_ID] || []).length,
+                );
                 this.emit('sdpOffer', parsedMessagePayload, senderClientId);
                 if (!this.config.enableEarlyIceCandidateBuffering) {
                     this.emitPendingIceCandidates(senderClientId);
@@ -345,8 +349,12 @@ export class SignalingClient extends EventEmitter {
                 return;
             case MessageType.SDP_ANSWER:
                 this.hasReceivedRemoteSDPByClientId[senderClientId || SignalingClient.DEFAULT_CLIENT_ID] = true;
-                console.log('[SignalingClient] SDP_ANSWER received. Pending ICE candidates for', senderClientId || SignalingClient.DEFAULT_CLIENT_ID, ':',
-                    (this.pendingIceCandidatesByClientId[senderClientId || SignalingClient.DEFAULT_CLIENT_ID] || []).length);
+                console.log(
+                    '[SignalingClient] SDP_ANSWER received. Pending ICE candidates for',
+                    senderClientId || SignalingClient.DEFAULT_CLIENT_ID,
+                    ':',
+                    (this.pendingIceCandidatesByClientId[senderClientId || SignalingClient.DEFAULT_CLIENT_ID] || []).length,
+                );
                 this.emit('sdpAnswer', parsedMessagePayload, senderClientId);
                 if (!this.config.enableEarlyIceCandidateBuffering) {
                     this.emitPendingIceCandidates(senderClientId);
@@ -399,9 +407,14 @@ export class SignalingClient extends EventEmitter {
                 this.pendingIceCandidatesByClientId[clientIdKey] = [];
             }
             this.pendingIceCandidatesByClientId[clientIdKey].push(iceCandidate);
-            console.log('[SignalingClient] ICE candidate arrived before SDP for', clientIdKey,
-                '- buffered. Pending count:', this.pendingIceCandidatesByClientId[clientIdKey].length,
-                'Candidate:', JSON.stringify(iceCandidate));
+            console.log(
+                '[SignalingClient] ICE candidate arrived before SDP for',
+                clientIdKey,
+                '- buffered. Pending count:',
+                this.pendingIceCandidatesByClientId[clientIdKey].length,
+                'Candidate:',
+                JSON.stringify(iceCandidate),
+            );
         }
     }
 

--- a/src/SignalingClient.ts
+++ b/src/SignalingClient.ts
@@ -27,6 +27,18 @@ export interface SignalingClientConfig {
     role: Role;
     clientId?: string;
     systemClockOffset?: number;
+    /**
+     * When true, ICE candidates that arrive before the SDP will be buffered and NOT automatically
+     * emitted after the SDP is received. The consumer must call `drainPendingIceCandidates()`
+     * after `setRemoteDescription` completes to release them.
+     *
+     * When false (default), ICE candidates are automatically emitted after the SDP event,
+     * preserving backward-compatible behavior.
+     *
+     * Set to true when connecting to a media server, where ICE candidates often arrive
+     * before the SDP and the consumer needs explicit control over when they are processed.
+     */
+    enableEarlyIceCandidateBuffering?: boolean;
 }
 
 enum MessageType {
@@ -209,6 +221,36 @@ export class SignalingClient extends EventEmitter {
     }
 
     /**
+     * Emits any pending ICE candidates for the given client. Call this after processing the remote SDP
+     * (e.g., after `setRemoteDescription` completes) to ensure ICE candidates are only emitted when the
+     * peer connection is ready to handle them.
+     *
+     * When using a media server, ICE candidates may arrive before or immediately after the SDP answer.
+     * This method gives the consumer explicit control over when those queued candidates are released.
+     *
+     * @param {string} [clientId] - The client ID to drain candidates for. Required for 'MASTER' role.
+     */
+    public drainPendingIceCandidates(clientId?: string): void {
+        this.emitPendingIceCandidates(clientId);
+    }
+
+    /**
+     * Returns the pending ICE candidates for the given client.
+     * Useful for debugging to check if candidates are stuck in the queue.
+     */
+    public getPendingIceCandidates(clientId?: string): object[] {
+        const clientIdKey = clientId || SignalingClient.DEFAULT_CLIENT_ID;
+        return this.pendingIceCandidatesByClientId[clientIdKey] || [];
+    }
+
+    /**
+     * Returns whether auto ICE candidate drain is disabled.
+     */
+    public isEarlyIceCandidateBufferingEnabled(): boolean {
+        return this.config.enableEarlyIceCandidateBuffering === true;
+    }
+
+    /**
      * Validates the WebSocket connection is open and that the recipient client id is present if sending as the 'MASTER'. Encodes the given message payload
      * and sends the message to the signaling service.
      */
@@ -279,12 +321,22 @@ export class SignalingClient extends EventEmitter {
 
         switch (messageType) {
             case MessageType.SDP_OFFER:
+                this.hasReceivedRemoteSDPByClientId[senderClientId || SignalingClient.DEFAULT_CLIENT_ID] = true;
+                console.log('[SignalingClient] SDP_OFFER received. Pending ICE candidates for', senderClientId || SignalingClient.DEFAULT_CLIENT_ID, ':',
+                    (this.pendingIceCandidatesByClientId[senderClientId || SignalingClient.DEFAULT_CLIENT_ID] || []).length);
                 this.emit('sdpOffer', parsedMessagePayload, senderClientId);
-                this.emitPendingIceCandidates(senderClientId);
+                if (!this.config.enableEarlyIceCandidateBuffering) {
+                    this.emitPendingIceCandidates(senderClientId);
+                }
                 return;
             case MessageType.SDP_ANSWER:
+                this.hasReceivedRemoteSDPByClientId[senderClientId || SignalingClient.DEFAULT_CLIENT_ID] = true;
+                console.log('[SignalingClient] SDP_ANSWER received. Pending ICE candidates for', senderClientId || SignalingClient.DEFAULT_CLIENT_ID, ':',
+                    (this.pendingIceCandidatesByClientId[senderClientId || SignalingClient.DEFAULT_CLIENT_ID] || []).length);
                 this.emit('sdpAnswer', parsedMessagePayload, senderClientId);
-                this.emitPendingIceCandidates(senderClientId);
+                if (!this.config.enableEarlyIceCandidateBuffering) {
+                    this.emitPendingIceCandidates(senderClientId);
+                }
                 return;
             case MessageType.ICE_CANDIDATE:
                 this.emitOrQueueIceCandidate(parsedMessagePayload, senderClientId);
@@ -326,12 +378,16 @@ export class SignalingClient extends EventEmitter {
     private emitOrQueueIceCandidate(iceCandidate: object, clientId?: string): void {
         const clientIdKey = clientId || SignalingClient.DEFAULT_CLIENT_ID;
         if (this.hasReceivedRemoteSDPByClientId[clientIdKey]) {
+            console.log('[SignalingClient] ICE candidate arrived AFTER SDP for', clientIdKey, '- emitting immediately');
             this.emit('iceCandidate', iceCandidate, clientId);
         } else {
             if (!this.pendingIceCandidatesByClientId[clientIdKey]) {
                 this.pendingIceCandidatesByClientId[clientIdKey] = [];
             }
             this.pendingIceCandidatesByClientId[clientIdKey].push(iceCandidate);
+            console.log('[SignalingClient] ICE candidate arrived before SDP for', clientIdKey,
+                '- buffered. Pending count:', this.pendingIceCandidatesByClientId[clientIdKey].length,
+                'Candidate:', JSON.stringify(iceCandidate));
         }
     }
 
@@ -345,6 +401,7 @@ export class SignalingClient extends EventEmitter {
         if (!pendingIceCandidates) {
             return;
         }
+        console.log('[SignalingClient] DRAINING', pendingIceCandidates.length, 'pending ICE candidates for', clientIdKey);
         delete this.pendingIceCandidatesByClientId[clientIdKey];
         pendingIceCandidates.forEach((iceCandidate) => {
             this.emit('iceCandidate', iceCandidate, clientId);

--- a/src/SignalingClient.ts
+++ b/src/SignalingClient.ts
@@ -257,7 +257,7 @@ export class SignalingClient extends EventEmitter {
      */
     public getPendingIceCandidates(clientId?: string): object[] {
         const clientIdKey = clientId || SignalingClient.DEFAULT_CLIENT_ID;
-        return this.pendingIceCandidatesByClientId[clientIdKey] || [];
+        return [...(this.pendingIceCandidatesByClientId[clientIdKey] || [])];
     }
 
     /**
@@ -439,7 +439,11 @@ export class SignalingClient extends EventEmitter {
         pendingIceCandidates.forEach((iceCandidate) => {
             const hadListeners = this.emit('iceCandidate', iceCandidate, clientId);
             if (!hadListeners) {
-                this.logger?.warn(SignalingClient.LOG_PREFIX, 'No iceCandidate listener attached. ICE candidate was emitted but not handled.');
+                this.logger?.warn(
+                    SignalingClient.LOG_PREFIX,
+                    'No iceCandidate listener attached. ICE candidate was emitted but not handled.',
+                    JSON.stringify(iceCandidate),
+                );
             }
         });
     }

--- a/src/SignalingClient.ts
+++ b/src/SignalingClient.ts
@@ -252,20 +252,6 @@ export class SignalingClient extends EventEmitter {
     }
 
     /**
-     * Resets the ICE candidate queuing state for the given client.
-     * Call this before a retry/reconnect so that ICE candidates arriving before the new SDP
-     * are correctly queued instead of being emitted to nonexistent listeners.
-     *
-     * @param {string} [clientId] - The client ID to reset state for. If omitted, resets the default client.
-     */
-    public resetIceCandidateState(clientId?: string): void {
-        const clientIdKey = clientId || SignalingClient.DEFAULT_CLIENT_ID;
-        delete this.hasReceivedRemoteSDPByClientId[clientIdKey];
-        delete this.pendingIceCandidatesByClientId[clientIdKey];
-        console.debug(SignalingClient.LOG_PREFIX, 'ICE candidate state reset for', clientIdKey);
-    }
-
-    /**
      * Validates the WebSocket connection is open and that the recipient client id is present if sending as the 'MASTER'. Encodes the given message payload
      * and sends the message to the signaling service.
      */

--- a/webpack.dist.config.js
+++ b/webpack.dist.config.js
@@ -3,7 +3,7 @@ const TerserPlugin = require('terser-webpack-plugin');
 const { merge } = require('webpack-merge');
 
 // Define maximum asset size before gzipping
-const MAX_ASSET_SIZE_KIB = 30;
+const MAX_ASSET_SIZE_KIB = 32;
 const MAX_ASSET_SIZE_BYTES = MAX_ASSET_SIZE_KIB * 1024;
 
 module.exports = merge(require('./webpack.config'), {


### PR DESCRIPTION
*Issue #, if available:*

In media server (ingestion) mode, ICE candidates arriving before the SDP offer are auto-drained immediately after the SDP event. Since `setRemoteDescription` is async, candidates are emitted before the peer connection is ready to handle them, causing connection failures on the first attempt.

*Description of changes:*

_What was changed?_

- Added `enableEarlyIceCandidateBuffering` config option to `SignalingClient` for explicit control over ICE candidate drain timing
- Added `getPendingIceCandidates()`, `isEarlyIceCandidateBufferingEnabled()`, and `drainPendingIceCandidates()` public methods
- Added optional `logger` config to `SignalingClient` — SDK is silent by default, users pass in a logger (e.g. `console`) to enable diagnostic logging
- Updated `channelHelper.js`, `answerer.js`, `viewer.js`, and `master.js` examples to use the new buffering API and pass `console` as the logger
- Added diagnostic logging for ICE candidate buffering and draining
- Added new APIs to README reference
- Dropped Node 18 and 19 from CI matrix
- Bumped max asset size to 32 KiB for added diagnostic logging

_Why was it changed?_

- In ingestion mode, ICE candidates frequently arrive before the SDP offer. The SDK auto-drained these candidates immediately after emitting the SDP event. Since `setRemoteDescription` is async, candidates were emitted before the peer connection was ready, causing connection failures.
- Node 18/19 are incompatible with current dependencies (eslint@10, jest@30, jsdom@29).
- Logging was hardcoded to `console` with no way for users to redirect or disable it.

_How was it changed?_

- `enableEarlyIceCandidateBuffering` (default: `false`) controls drain behavior. When `false`, auto-drains after SDP event (backward compatible for P2P). When `true`, consumer must call `drainPendingIceCandidates()` after `setRemoteDescription`.
- `channelHelper.js` sets the flag when ingestion mode is active.
- `Answerer` accepts the flag and calls `drainPendingIceCandidates()` after `setRemoteDescription` when buffering is enabled.
- All direct `console` calls replaced with `this.logger?.debug/log/warn`. Logger is optional — silent by default.
- Examples pass `logger: console` to enable logging.
- Extracted `[SignalingClient]` log prefix to `LOG_PREFIX` constant.

_What testing was done for the changes?_

- Updated unit tests to reflect new drain behavior
- Manually verified P2P mode: auto-drain preserved, connection succeeds
- Manually verified ingestion mode: early ICE candidates buffered and drained correctly

P2P viewer (auto-drain, default behavior):
```
[SignalingClient] ICE candidate arrived before SDP for MASTER - buffered. Pending count: 1
[SignalingClient] ICE candidate arrived before SDP for MASTER - buffered. Pending count: 2
[SignalingClient] SDP_ANSWER received. Pending ICE candidates for MASTER : 2
[VIEWER] Received SDP answer
[SignalingClient] DRAINING 2 pending ICE candidates for MASTER
```

Ingestion viewer (buffering enabled, explicit drain after setRemoteDescription):
```
[SignalingClient] ICE candidate arrived before SDP for MASTER - buffered. Pending count: 1
[SignalingClient] SDP_OFFER received. Pending ICE candidates for MASTER : 1
[VIEWER] Received SDP offer from remote
[VIEWER] Received audio track from remote
[VIEWER] Received video track from remote
[SignalingClient] DRAINING 1 pending ICE candidates for MASTER
[VIEWER] Received ICE candidate from remote
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
