### PR TITLE
ci: drop Node 18 and 19 from CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node: [ 18, 19, 20, 21, 22, 23 ]
+        node: [ 20, 21, 22, 23 ]
       fail-fast: false
     steps:
       - name: Checkout repository


### PR DESCRIPTION
*Issue #, if available:*
- Eslint@10 require Node >= 20.
- ESLint 10.2.0's stylish formatter calls util.styleText(), which doesn't exist on the util module. This makes CI get _TypeError: util.styleText is not a function._

*Description of changes:*
- drop Node 18 and 19 from CI matrix

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
