### PR TITLE
Display SDK version dynamically next to test page title

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -251,6 +251,7 @@ $('#master-button').click(async () => {
 
     printFormValues(formValues);
 
+    console.log(`[${ROLE}] SDK version: ${KVSWebRTC.VERSION || 'unknown'}`);
     startMaster(localView, remoteView, formValues, onStatsReport, event => {
         remoteMessage.append(`${event.data}\n`);
     });
@@ -343,6 +344,7 @@ $('#viewer-button').click(async () => {
 
     printFormValues(formValues);
 
+    console.log(`[VIEWER] SDK version: ${KVSWebRTC.VERSION || 'unknown'}`);
     startViewer(localView, remoteView, formValues, onStatsReport, remoteMessage);
 });
 

--- a/examples/app.js
+++ b/examples/app.js
@@ -3,6 +3,16 @@ const LOG_LEVELS = ['debug', 'info', 'warn', 'error'];
 let LOG_LEVEL = 'info'; // Possible values: any value of LOG_LEVELS
 let channelHelper = null; // Holder for channelHelper
 
+// Display SDK version dynamically from package.json
+fetch('../package.json')
+    .then(response => response.json())
+    .then(pkg => {
+        document.getElementById('sdk-version').textContent = 'v' + pkg.version;
+    })
+    .catch(() => {
+        document.getElementById('sdk-version').textContent = 'v' + (KVSWebRTC.VERSION || 'unknown');
+    });
+
 // All supported codecs
 const allVCodecs = RTCRtpSender.getCapabilities('video').codecs;
 const allACodecs = RTCRtpSender.getCapabilities('audio').codecs;

--- a/examples/index.html
+++ b/examples/index.html
@@ -19,7 +19,7 @@
 <body>
 
 <div class="container mt-3">
-    <h1>KVS WebRTC Test Page</h1>
+    <h1>KVS WebRTC Test Page <small class="text-muted" id="sdk-version"></small></h1>
     <p>This is the KVS Signaling Channel WebRTC test page. Use this page to connect to a signaling channel as either the MASTER or as a VIEWER.</p>
 
     <div class="row loader"></div>


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*Description of changes:*
- Display the SDK version next to the "KVS WebRTC Test Page" heading.
<img width="499" height="62" alt="image" src="https://github.com/user-attachments/assets/eaba4fc9-61b8-4f7b-ac2b-717f6f6aab0d" />

- Display the SDK version in the log
<img width="507" height="35" alt="image" src="https://github.com/user-attachments/assets/d8005133-168d-43b1-bc99-51fd2bee66fc" />




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
