### PR TITLE
fix: reset ICE candidate state on ingestion retry to prevent candidate loss during reconnection

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,10 @@ Returns the pending ICE candidates for the given client. Useful for debugging to
 * `clientId` {string} The client ID to get pending candidates for. If omitted, returns candidates for the default client.
 * `return` {object[]} Array of pending ICE candidate objects.
 
+#### Method: `resetIceCandidateState([clientId])`
+Resets the ICE candidate state for a given client. Clears the `hasReceivedRemoteSDPByClientId` flag and any pending ICE candidates so that on reconnection, candidates arriving before the new SDP offer are properly queued. Call this before retrying a peer connection (e.g., in ingestion mode) to prevent candidate loss.
+* `clientId` {string} The client ID to reset state for. Required for 'MASTER' role. If omitted, resets for the default client.
+
 #### Method: `isEarlyIceCandidateBufferingEnabled() => boolean`
 Returns whether early ICE candidate buffering is enabled in the client configuration.
 * `return` {boolean} `true` if `enableEarlyIceCandidateBuffering` was set to `true` in the config.

--- a/examples/master.js
+++ b/examples/master.js
@@ -318,6 +318,7 @@ function onPeerConnectionFailed(remoteClientId, printLostConnectionLog = true) {
         console.warn(`[${role}] Reconnecting...`);
 
         master.sdpOfferReceived = false;
+        master.channelHelper.getSignalingClient().resetIceCandidateState(remoteClientId);
         if (!master.websocketOpened) {
             const channelHelper = master.channelHelper;
             if (channelHelper) {

--- a/src/SignalingClient.spec.ts
+++ b/src/SignalingClient.spec.ts
@@ -687,6 +687,56 @@ describe('SignalingClient', () => {
             });
         });
 
+        describe('resetIceCandidateState', () => {
+            it('should clear pending ICE candidates for the default client ID (viewer)', (done) => {
+                const client = new SignalingClient(config as SignalingClientConfig);
+                client.on('open', () => {
+                    MockWebSocket.instance.emit('message', { data: ICE_CANDIDATE_MASTER_MESSAGE });
+                    expect(client.getPendingIceCandidates().length).toEqual(1);
+                    client.resetIceCandidateState();
+                    expect(client.getPendingIceCandidates().length).toEqual(0);
+                    done();
+                });
+                client.open();
+            });
+
+            it('should clear pending ICE candidates for a specific client ID (master)', (done) => {
+                config.role = Role.MASTER;
+                delete config.clientId;
+                const client = new SignalingClient(config as SignalingClientConfig);
+                client.on('open', () => {
+                    MockWebSocket.instance.emit('message', { data: ICE_CANDIDATE_VIEWER_MESSAGE });
+                    expect(client.getPendingIceCandidates(CLIENT_ID).length).toEqual(1);
+                    client.resetIceCandidateState(CLIENT_ID);
+                    expect(client.getPendingIceCandidates(CLIENT_ID).length).toEqual(0);
+                    done();
+                });
+                client.open();
+            });
+
+            it('should reset hasReceivedRemoteSDPByClientId so that candidates are buffered again', (done) => {
+                const client = new SignalingClient(config as SignalingClientConfig);
+                client.on('open', () => {
+                    // Receive SDP to set hasReceivedRemoteSDPByClientId = true
+                    MockWebSocket.instance.emit('message', { data: SDP_ANSWER_MASTER_MESSAGE });
+                    // Reset state
+                    client.resetIceCandidateState();
+                    // Now ICE candidates should be buffered again instead of emitted immediately
+                    MockWebSocket.instance.emit('message', { data: ICE_CANDIDATE_MASTER_MESSAGE });
+                    expect(client.getPendingIceCandidates().length).toEqual(1);
+                    done();
+                });
+                client.open();
+            });
+
+            it('should work without a logger configured', () => {
+                const noLoggerConfig = { ...config };
+                delete noLoggerConfig.logger;
+                const client = new SignalingClient(noLoggerConfig as SignalingClientConfig);
+                expect(() => client.resetIceCandidateState()).not.toThrow();
+            });
+        });
+
         describe('getPendingIceCandidates', () => {
             it('should return empty array when no candidates are pending', () => {
                 const client = new SignalingClient(config as SignalingClientConfig);

--- a/src/SignalingClient.ts
+++ b/src/SignalingClient.ts
@@ -268,6 +268,25 @@ export class SignalingClient extends EventEmitter {
     }
 
     /**
+     * Resets the ICE candidate state for a given client. This clears the
+     * hasReceivedRemoteSDPByClientId flag and any pending ICE candidates,
+     * so that on reconnection, ICE candidates arriving before the new SDP
+     * offer will be properly queued instead of emitted immediately to
+     * a non-existent listener.
+     *
+     * Call this before retrying a peer connection (e.g., in ingestion mode)
+     * to prevent candidate loss.
+     *
+     * @param {string} [clientId] - The client ID to reset state for. Required for 'MASTER' role.
+     */
+    public resetIceCandidateState(clientId?: string): void {
+        const clientIdKey = clientId || SignalingClient.DEFAULT_CLIENT_ID;
+        delete this.hasReceivedRemoteSDPByClientId[clientIdKey];
+        delete this.pendingIceCandidatesByClientId[clientIdKey];
+        this.logger?.debug(SignalingClient.LOG_PREFIX, 'ICE candidate state reset for', clientIdKey);
+    }
+
+    /**
      * Validates the WebSocket connection is open and that the recipient client id is present if sending as the 'MASTER'. Encodes the given message payload
      * and sends the message to the signaling service.
      */


### PR DESCRIPTION
*Issue #, if available:*

- On the receiving side, sometimes SDK receives ICE candidate from the media server before the SDP offer. In the previous investigation, we re-designed the SDK logic to buffer early arrived ICE candidate and emit later when ICE candidate listener has been initialized for the first JoinStorageSession call. In the design, we noted that there needs to be additional work to handle the reconnect case. This PR handles the reconnect case.

*Description of changes:*

_What was changed?_

- Added a new public method `resetIceCandidateState(clientId?)` to `SignalingClient` that clears `hasReceivedRemoteSDPByClientId` and `pendingIceCandidatesByClientId` for a given client
- Updated `examples/master.js` to call `resetIceCandidateState` before retrying a peer connection in the ingestion reconnection flow

_Why was it changed?_

- During WebRTC ingestion reconnection, ICE candidates could be lost because the hasReceivedRemoteSDPByClientId flag from the previous connection was never cleared between retries. This caused early-arriving ICE candidates to be emitted immediately (instead of buffered), and since no iceCandidate event listener was attached yet on the new peer connection, those candidates were dropped. 

_How was it changed?_

- `resetIceCandidateState` deletes the remote SDP received flag and pending ICE candidate queue for the specified client ID, restoring the pre-connection state
- The method is called in `onPeerConnectionFailed` (master.js) before the reconnection logic runs, ensuring candidates for the new connection are properly buffered until the new SDP offer arrives

_What testing was done for the changes?_
- Manual Tests
BEFORE: 
<img width="958" height="278" alt="image" src="https://github.com/user-attachments/assets/36335f51-cf95-46f1-9676-f2ad98df276a" />
AFTER: 
<img width="965" height="227" alt="image" src="https://github.com/user-attachments/assets/5df5dbbf-ba2b-484c-82cb-f7c0624da485" />

- Canary Tests: Higher Peer Connection Availability with the fix
With the fix:
<img width="942" height="299" alt="image" src="https://github.com/user-attachments/assets/f627a9d3-6e0e-4aef-b5e4-82db8bdd18e2" />
Without the fix:
<img width="2103" height="501" alt="image" src="https://github.com/user-attachments/assets/9568d0cd-7b32-4eb3-89a5-d5c7d9427b0b" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
