### PR TITLE
Add multi-track support for p2p viewer

### DIFF
--- a/examples/app.css
+++ b/examples/app.css
@@ -6,6 +6,27 @@
     width: 100%;
 }
 
+.video-container .track-label {
+    display: block;
+    background: rgba(0, 0, 0, 0.8);
+    color: white;
+    padding: 2px 6px;
+    font-size: 12px;
+    line-height: 1.4;
+    font-family: monospace;
+}
+
+.video-container audio {
+    width: 100%;
+    max-width: 100%;
+}
+
+.remote-views {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 4px;
+}
+
 
 #logs-header {
     margin-top: 20px;

--- a/examples/app.js
+++ b/examples/app.js
@@ -116,6 +116,7 @@ function getFormValues() {
         autoDetermineMediaIngestMode: $('#ingest-media').is(':checked'),
         showJSSButton: $('#show-join-storage-session-button').is(':checked'),
         showJSSAsViewerButton: $('#show-join-storage-session-as-viewer-button').is(':checked'),
+        receiveMultiTrack: $('#receiveMultiTrack').is(':checked'),
         openDataChannel: $('#openDataChannel').is(':checked'),
         widescreen: $('#widescreen').is(':checked'),
         fullscreen: $('#fullscreen').is(':checked'),
@@ -325,7 +326,7 @@ $('#viewer-button').click(async () => {
     $('#viewer').removeClass('d-none');
 
     const localView = $('#viewer .local-view')[0];
-    const remoteView = $('#viewer .remote-view')[0];
+    const remoteViewContainer = $('#viewer .remote-views')[0];
     const localMessage = $('#viewer .local-message')[0];
     const remoteMessage = $('#viewer .remote-message')[0];
 
@@ -345,7 +346,7 @@ $('#viewer-button').click(async () => {
     printFormValues(formValues);
 
     console.log(`[VIEWER] SDK version: ${KVSWebRTC.VERSION || 'unknown'}`);
-    startViewer(localView, remoteView, formValues, onStatsReport, remoteMessage);
+    startViewer(localView, remoteViewContainer, formValues, onStatsReport, remoteMessage);
 });
 
 function updateViewerUI() {
@@ -660,6 +661,7 @@ const fields = [
     {field: 'show-join-storage-session-as-viewer-button', type: 'checkbox'},
     {field: 'widescreen', type: 'radio', name: 'resolution'},
     {field: 'fullscreen', type: 'radio', name: 'resolution'},
+    {field: 'receiveMultiTrack', type: 'checkbox'},
     {field: 'openDataChannel', type: 'checkbox'},
     {field: 'useTrickleICE', type: 'checkbox'},
     {field: 'natTraversalEnabled', type: 'radio', name: 'natTraversal'},

--- a/examples/index.html
+++ b/examples/index.html
@@ -81,6 +81,11 @@
                     <a href=&quot;https://www.w3.org/TR/webrtc/#rtcdatachannel&quot;>Additional information</a>
                     "><sup>&#9432;</sup></span>
                 </div>
+                <br/>
+                <div class="form-check-inline">
+                    <input class="form-check-input" type="checkbox" id="receiveMultiTrack" value="multitrack">
+                    <label for="receiveMultiTrack" class="form-check-label">Receive Multi-Track <small>(P2P viewer only)</small></label>
+                </div>
             </div>
             <details id="webrtc-ingestion-and-storage-group"><summary class="h4" id="subheader">WebRTC Ingestion and Storage</summary>
             <div>
@@ -394,7 +399,7 @@
                     </div>
                     <small id="fips-region-warning" class="text-danger d-none">FIPS endpoints not supported in this region.</small>
                 </div>
-                                    
+
                 <p class="mt-3"><small>Endpoint Override</small></p>
                 <div class="form-group">
                     <input type="text" class="form-control" id="endpoint" placeholder="Endpoint">
@@ -481,7 +486,7 @@
                 </div>
                 <div class="col">
                     <h5>From Master</h5>
-                    <div class="video-container"><video class="remote-view" autoplay playsinline controls></video></div>
+                    <div class="remote-views"><div class="video-container"><video class="remote-view" autoplay playsinline controls></video></div></div>
                 </div>
             </div>
             <div class="row datachannel">

--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -256,7 +256,7 @@ let dataChannelLatencyCalcMessage = {
     'lastMessageFromViewerTs': ''
 }
 
-async function startViewer(localView, remoteView, formValues, onStatsReport, remoteMessage) {
+async function startViewer(localView, remoteViewContainer, formValues, onStatsReport, remoteMessage) {
     try {
         console.log('[VIEWER] Client id is:', formValues.clientId);
         viewerButtonPressed = new Date();
@@ -266,7 +266,9 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, rem
         }
 
         viewer.localView = localView;
-        viewer.remoteView = remoteView;
+        viewer.remoteViewContainer = remoteViewContainer;
+        viewer.remoteViews = [];
+        viewer.remoteStreams = [];
 
         viewer.loadedDataCallback = () => {
             metrics.viewer.ttff.endTime = Date.now();
@@ -285,8 +287,6 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, rem
                 timeToFirstFrameFromViewerStart = metrics.viewer.ttff.endTime - viewerButtonPressed.getTime();
             }
         };
-
-        viewer.remoteView.addEventListener('loadeddata', viewer.loadedDataCallback);
 
         if (formValues.enableProfileTimeline) {
             metrics.viewer.ttff.startTime = viewerButtonPressed.getTime();
@@ -718,6 +718,15 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, rem
                 }
             }
 
+            // Add recvonly video transceivers so the SDP offer signals we can receive up to 4 video tracks.
+            // The answerer (C SDK master) cannot add new m-lines - it can only send on m-lines present in the offer.
+            if (formValues.receiveMultiTrack) {
+                const existingVideoTransceivers = viewer.peerConnection.getTransceivers().filter(t => t.receiver.track.kind === 'video').length;
+                for (let i = existingVideoTransceivers; i < 4; i++) {
+                    viewer.peerConnection.addTransceiver('video', { direction: 'recvonly' });
+                }
+            }
+
             const [videoCodecs, audioCodecs] = getCodecFilters();
             viewer.peerConnection.getTransceivers().map((transceiver) => {
                 if (transceiver.receiver.track.kind === 'video' && videoCodecs) {
@@ -821,16 +830,163 @@ async function startViewer(localView, remoteView, formValues, onStatsReport, rem
                 'with track id:',
                 event.track.id,
             );
-            if (remoteView.srcObject) {
+
+            if (event.track.kind !== 'video') {
+                // Single video track: attach audio directly to the video element (1V+1A backwards compat)
+                if (viewer.remoteViews.length <= 1 && !viewer.audioElement) {
+                    // If audio arrives before video, buffer the track to attach once video arrives
+                    if (viewer.remoteViews.length === 0) {
+                        viewer.pendingAudioTrack = event.track;
+                        viewer.pendingAudioStreamName = event.streams[0]?.id || event.track.label || event.track.id;
+                        return;
+                    }
+                    viewer.remoteViews[0].srcObject.addTrack(event.track);
+                    const videoLabel = viewer.remoteViews[0].parentElement.querySelector('.track-label');
+                    const audioStreamName = event.streams[0]?.id || event.track.label || event.track.id;
+                    viewer.audioTrackLabel = audioStreamName;
+                    if (videoLabel) {
+                        const videoStreamName = videoLabel.textContent;
+                        if (audioStreamName === videoStreamName) {
+                            videoLabel.textContent = videoStreamName + ' (video + audio)';
+                        } else {
+                            videoLabel.textContent = videoStreamName + ' + ' + audioStreamName;
+                        }
+                    }
+                    return;
+                }
+                // Multi-video: use a separate audio element
+                if (!viewer.audioElement) {
+                    const audioContainer = document.createElement('div');
+                    audioContainer.classList.add('video-container');
+
+                    const audioName = event.streams[0]?.id || event.track.label || event.track.id;
+                    const audioLabel = document.createElement('span');
+                    audioLabel.classList.add('track-label');
+                    audioLabel.textContent = audioName.toLowerCase().includes('audio') ? audioName : audioName + ' (audio)';
+                    audioContainer.appendChild(audioLabel);
+
+                    viewer.audioElement = document.createElement('audio');
+                    viewer.audioElement.autoplay = true;
+                    viewer.audioElement.controls = true;
+                    viewer.audioElement.srcObject = new MediaStream();
+                    audioContainer.appendChild(viewer.audioElement);
+                    remoteViewContainer.appendChild(audioContainer);
+                }
+                viewer.audioElement.srcObject.addTrack(event.track);
                 return;
             }
-            viewer.remoteStream = event.streams[0];
-            remoteView.srcObject = viewer.remoteStream;
 
-            //measure the time to first track
+            if (viewer.remoteViews.length >= 4) {
+                console.warn('[VIEWER] Maximum of 4 video tracks reached, ignoring additional track');
+                return;
+            }
+
+            // When a 2nd video track arrives, move audio out of the first video element
+            // into a separate audio element (transition from 1V+1A to multi-track).
+            if (viewer.remoteViews.length === 1 && !viewer.audioElement) {
+                const firstStream = viewer.remoteViews[0].srcObject;
+                const audioTracks = firstStream.getAudioTracks();
+                if (audioTracks.length > 0) {
+                    // Remove the audio portion from the first video's label
+                    const firstLabel = viewer.remoteViews[0].parentElement.querySelector('.track-label');
+                    if (firstLabel) {
+                        if (firstLabel.textContent.endsWith(' (video + audio)')) {
+                            firstLabel.textContent = firstLabel.textContent.slice(0, -' (video + audio)'.length);
+                        } else if (viewer.audioTrackLabel && firstLabel.textContent.endsWith(' + ' + viewer.audioTrackLabel)) {
+                            firstLabel.textContent = firstLabel.textContent.slice(0, -(' + ' + viewer.audioTrackLabel).length);
+                        }
+                    }
+
+                    const audioContainer = document.createElement('div');
+                    audioContainer.classList.add('video-container');
+
+                    const audioLabel = document.createElement('span');
+                    audioLabel.classList.add('track-label');
+                    const transitionAudioName = viewer.audioTrackLabel || 'audio';
+                    audioLabel.textContent = transitionAudioName.toLowerCase().includes('audio') ? transitionAudioName : transitionAudioName + ' (audio)';
+                    audioContainer.appendChild(audioLabel);
+
+                    viewer.audioElement = document.createElement('audio');
+                    viewer.audioElement.autoplay = true;
+                    viewer.audioElement.controls = true;
+                    viewer.audioElement.srcObject = new MediaStream();
+                    audioContainer.appendChild(viewer.audioElement);
+                    remoteViewContainer.appendChild(audioContainer);
+                    audioTracks.forEach(track => {
+                        firstStream.removeTrack(track);
+                        viewer.audioElement.srcObject.addTrack(track);
+                    });
+                }
+            }
+
+            let videoElement;
+            let container;
+
+            // Reuse the existing placeholder video element for the first track, or create one if cleared by stopViewer()
+            if (viewer.remoteViews.length === 0) {
+                container = remoteViewContainer.querySelector('.video-container');
+                if (container) {
+                    videoElement = container.querySelector('.remote-view');
+                }
+                if (!videoElement) {
+                    videoElement = document.createElement('video');
+                    videoElement.autoplay = true;
+                    videoElement.setAttribute('playsinline', '');
+                    videoElement.controls = true;
+                    container = document.createElement('div');
+                    container.classList.add('video-container');
+                    remoteViewContainer.appendChild(container);
+                }
+            } else {
+                videoElement = document.createElement('video');
+                videoElement.autoplay = true;
+                videoElement.setAttribute('playsinline', '');
+                videoElement.controls = true;
+
+                container = document.createElement('div');
+                container.classList.add('video-container');
+                remoteViewContainer.appendChild(container);
+            }
+
+            const trackLabel = document.createElement('span');
+            trackLabel.classList.add('track-label');
+            trackLabel.textContent = event.streams[0]?.id || event.track.label || event.track.id;
+            container.insertBefore(trackLabel, container.firstChild);
+            container.appendChild(videoElement);
+
+            const stream = new MediaStream([event.track]);
+            videoElement.srcObject = stream;
+
+            viewer.remoteViews.push(videoElement);
+            viewer.remoteStreams.push(stream);
+
+            // If audio arrived before this first video, attach it now
+            if (viewer.remoteViews.length === 1 && viewer.pendingAudioTrack) {
+                stream.addTrack(viewer.pendingAudioTrack);
+                viewer.audioTrackLabel = viewer.pendingAudioStreamName;
+                const label = container.querySelector('.track-label');
+                if (label) {
+                    const videoStreamName = label.textContent;
+                    if (viewer.pendingAudioStreamName === videoStreamName) {
+                        label.textContent = videoStreamName + ' (video + audio)';
+                    } else {
+                        label.textContent = videoStreamName + ' + ' + viewer.pendingAudioStreamName;
+                    }
+                }
+                viewer.pendingAudioTrack = null;
+                viewer.pendingAudioStreamName = null;
+            }
+
+            // Attach time-to-first-frame listener on the first video track
+            if (viewer.remoteViews.length === 1) {
+                videoElement.addEventListener('loadeddata', viewer.loadedDataCallback);
+            }
+
             if (formValues.enableDQPmetrics && initialDate === 0) {
                 initialDate = new Date();
             }
+
+            console.log('[VIEWER] Now displaying', viewer.remoteViews.length, 'video track(s)');
         });
 
         console.log('[VIEWER] Starting viewer connection');
@@ -859,9 +1015,9 @@ function stopViewer() {
             viewer.localStream = null;
         }
 
-        if (viewer.remoteStream) {
-            viewer.remoteStream.getTracks().forEach(track => track.stop());
-            viewer.remoteStream = null;
+        if (viewer.remoteStreams) {
+            viewer.remoteStreams.forEach(stream => stream.getTracks().forEach(track => track.stop()));
+            viewer.remoteStreams = null;
         }
 
         if (viewer.peerConnectionStatsInterval) {
@@ -873,9 +1029,25 @@ function stopViewer() {
             viewer.localView.srcObject = null;
         }
 
-        if (viewer.remoteView) {
-            viewer.remoteView.removeEventListener('loadeddata', viewer.loadedDataCallback);
-            viewer.remoteView.srcObject = null;
+        if (viewer.remoteViews) {
+            viewer.remoteViews.forEach(view => {
+                view.removeEventListener('loadeddata', viewer.loadedDataCallback);
+                view.srcObject = null;
+            });
+            viewer.remoteViews = null;
+        }
+
+        viewer.pendingAudioTrack = null;
+        viewer.pendingAudioStreamName = null;
+
+        if (viewer.audioElement) {
+            viewer.audioElement.srcObject?.getTracks().forEach(track => track.stop());
+            viewer.audioElement.srcObject = null;
+            viewer.audioElement = null;
+        }
+
+        if (viewer.remoteViewContainer) {
+            viewer.remoteViewContainer.innerHTML = '<div class="video-container"><video class="remote-view" autoplay playsinline controls></video></div>';
         }
 
         if (viewer.dataChannel) {

--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -764,15 +764,6 @@ async function startViewer(localView, remoteViewContainer, formValues, onStatsRe
             console.debug('SDP answer:', answer);
             metrics.viewer.offAnswerTime.endTime = Date.now();
             await viewer.peerConnection.setRemoteDescription(answer);
-
-            // Log transceiver directions after SDP answer is applied
-            if (formValues.receiveMultiTrack) {
-                viewer.peerConnection.getTransceivers().forEach(t => {
-                    if (t.currentDirection === 'inactive') {
-                        console.warn(`[VIEWER] Transceiver mid=${t.mid} (${t.receiver.track.kind}) is inactive - remote peer did not send on this m-line`);
-                    }
-                });
-            }
         });
 
         viewer.signalingClient.on('iceCandidate', candidate => {
@@ -827,9 +818,13 @@ async function startViewer(localView, remoteViewContainer, formValues, onStatsRe
             printPeerConnectionStateInfo(event, '[VIEWER]');
         });
 
-        // As remote tracks are received, add them to the remote view.
-        // Note: track events fire sequentially on the JS event loop (single-threaded) — no race conditions.
-        viewer.peerConnection.addEventListener('track', event => {
+        // As remote tracks are received, link them to the pre-created DOM elements.
+        // Track events fire sequentially (JS is single-threaded) — no race conditions.
+        //
+        // Display logic (determined from SDP answer, elements pre-created above):
+        //   1V + 1A (or less): single <video> element.
+        //   Otherwise: each track in a separate element.
+        viewer.peerConnection.addEventListener('track', (event) => {
             console.log(
                 '[VIEWER] Received',
                 event.track.kind || 'unknown',
@@ -841,156 +836,139 @@ async function startViewer(localView, remoteViewContainer, formValues, onStatsRe
                 event.track.id,
             );
 
-            if (event.track.kind !== 'video') {
-                // Single video track: attach audio directly to the video element (1V+1A backwards compat)
-                if (viewer.remoteViews.length === 1 && !viewer.audioElement) {
-                    viewer.remoteViews[0].srcObject.addTrack(event.track);
-                    const videoLabel = viewer.remoteViews[0].parentElement.querySelector('.track-label');
-                    const audioStreamName = event.streams[0]?.id || event.track.label || event.track.id;
-                    viewer.audioTrackLabel = audioStreamName;
-                    if (videoLabel) {
-                        const videoStreamName = videoLabel.textContent;
-                        if (audioStreamName === videoStreamName) {
-                            videoLabel.textContent = videoStreamName + ' (video + audio)';
-                        } else {
-                            videoLabel.textContent = videoStreamName + ' + ' + audioStreamName;
-                        }
+            // Lazy init: pre-create all DOM elements on the first ontrack event.
+            // At this point, setRemoteDescription has completed and transceivers have currentDirection set.
+            if (!viewer.viewInitialized) {
+                viewer.viewInitialized = true;
+                const activeTransceivers = viewer.peerConnection.getTransceivers().filter(
+                    (t) => t.currentDirection === 'recvonly' || t.currentDirection === 'sendrecv',
+                );
+                viewer.expectedVideoCount = activeTransceivers.filter((t) => t.receiver.track.kind === 'video').length;
+                const expectedAudioCount = activeTransceivers.filter((t) => t.receiver.track.kind === 'audio').length;
+                console.log(`[VIEWER] Expecting ${viewer.expectedVideoCount} video + ${expectedAudioCount} audio track(s) from remote`);
+
+                viewer.videoElements = [];
+                viewer.audioElements = [];
+                remoteViewContainer.innerHTML = '';
+
+                if (viewer.expectedVideoCount <= 1 && expectedAudioCount <= 1) {
+                    // Single combined <video> element for 1V+1A
+                    const container = document.createElement('div');
+                    container.classList.add('video-container');
+                    const videoEl = document.createElement('video');
+                    videoEl.autoplay = true;
+                    videoEl.setAttribute('playsinline', '');
+                    videoEl.controls = true;
+                    container.appendChild(videoEl);
+                    remoteViewContainer.appendChild(container);
+                    viewer.videoElements.push(videoEl);
+                } else {
+                    // Multi-track: one <video> per video track, one <audio> per audio track
+                    for (let i = 0; i < viewer.expectedVideoCount; i++) {
+                        const container = document.createElement('div');
+                        container.classList.add('video-container');
+                        const videoEl = document.createElement('video');
+                        videoEl.autoplay = true;
+                        videoEl.setAttribute('playsinline', '');
+                        videoEl.controls = true;
+                        container.appendChild(videoEl);
+                        remoteViewContainer.appendChild(container);
+                        viewer.videoElements.push(videoEl);
                     }
-                    return;
-                }
-                // Multi-video: use a separate audio element
-                if (!viewer.audioElement) {
-                    const audioContainer = document.createElement('div');
-                    audioContainer.classList.add('video-container');
-
-                    const audioName = event.streams[0]?.id || event.track.label || event.track.id;
-                    const audioLabel = document.createElement('span');
-                    audioLabel.classList.add('track-label');
-                    audioLabel.textContent = audioName.toLowerCase().includes('audio') ? audioName : audioName + ' (audio)';
-                    audioContainer.appendChild(audioLabel);
-
-                    viewer.audioElement = document.createElement('audio');
-                    viewer.audioElement.autoplay = true;
-                    viewer.audioElement.controls = true;
-                    viewer.audioElement.srcObject = new MediaStream();
-                    audioContainer.appendChild(viewer.audioElement);
-                    remoteViewContainer.appendChild(audioContainer);
-                }
-                viewer.audioElement.srcObject.addTrack(event.track);
-                return;
-            }
-
-            if (viewer.remoteViews.length >= 4) {
-                console.warn('[VIEWER] Maximum of 4 video tracks reached, ignoring additional track');
-                return;
-            }
-
-            // When a 2nd video track arrives, move audio out of the first video element
-            // into a separate audio element (transition from 1V+1A to multi-track).
-            if (viewer.remoteViews.length === 1 && !viewer.audioElement) {
-                const firstStream = viewer.remoteViews[0].srcObject;
-                const audioTracks = firstStream.getAudioTracks();
-                if (audioTracks.length > 0) {
-                    // Remove the audio portion from the first video's label
-                    const firstLabel = viewer.remoteViews[0].parentElement.querySelector('.track-label');
-                    if (firstLabel) {
-                        if (firstLabel.textContent.endsWith(' (video + audio)')) {
-                            firstLabel.textContent = firstLabel.textContent.slice(0, -' (video + audio)'.length);
-                        } else if (viewer.audioTrackLabel && firstLabel.textContent.endsWith(' + ' + viewer.audioTrackLabel)) {
-                            firstLabel.textContent = firstLabel.textContent.slice(0, -(' + ' + viewer.audioTrackLabel).length);
-                        }
+                    for (let i = 0; i < expectedAudioCount; i++) {
+                        const container = document.createElement('div');
+                        container.classList.add('video-container');
+                        const audioEl = document.createElement('audio');
+                        audioEl.autoplay = true;
+                        audioEl.controls = true;
+                        container.appendChild(audioEl);
+                        remoteViewContainer.appendChild(container);
+                        viewer.audioElements.push(audioEl);
                     }
+                }
 
-                    const audioContainer = document.createElement('div');
-                    audioContainer.classList.add('video-container');
+                viewer.videoIndex = 0;
+                viewer.audioIndex = 0;
 
-                    const audioLabel = document.createElement('span');
-                    audioLabel.classList.add('track-label');
-                    const transitionAudioName = viewer.audioTrackLabel || 'audio';
-                    audioLabel.textContent = transitionAudioName.toLowerCase().includes('audio') ? transitionAudioName : transitionAudioName + ' (audio)';
-                    audioContainer.appendChild(audioLabel);
-
-                    viewer.audioElement = document.createElement('audio');
-                    viewer.audioElement.autoplay = true;
-                    viewer.audioElement.controls = true;
-                    viewer.audioElement.srcObject = new MediaStream();
-                    audioContainer.appendChild(viewer.audioElement);
-                    remoteViewContainer.appendChild(audioContainer);
-                    audioTracks.forEach(track => {
-                        firstStream.removeTrack(track);
-                        viewer.audioElement.srcObject.addTrack(track);
+                // Log inactive transceivers as warnings
+                if (formValues.receiveMultiTrack) {
+                    viewer.peerConnection.getTransceivers().forEach((t) => {
+                        if (t.currentDirection === 'inactive') {
+                            console.warn(`[VIEWER] Transceiver mid=${t.mid} (${t.receiver.track.kind}) is inactive - remote peer did not send on this m-line`);
+                        }
                     });
                 }
             }
 
-            let videoElement;
-            let container;
+            const streamName = event.streams[0]?.id || event.track.label || event.track.id;
 
-            // Reuse the existing placeholder video element for the first track, or create one if cleared by stopViewer()
-            if (viewer.remoteViews.length === 0) {
-                container = remoteViewContainer.querySelector('.video-container');
-                if (container) {
-                    videoElement = container.querySelector('.remote-view');
+            if (event.track.kind !== 'video') {
+                if (viewer.expectedVideoCount <= 1) {
+                    // 1V+1A: add audio to the single video element
+                    const videoEl = viewer.videoElements[0];
+                    if (!videoEl.srcObject) {
+                        videoEl.srcObject = new MediaStream();
+                    }
+                    videoEl.srcObject.addTrack(event.track);
+                    // Update label
+                    const label = videoEl.parentElement.querySelector('.track-label');
+                    if (label) {
+                        const videoName = label.textContent;
+                        if (streamName === videoName) {
+                            label.textContent = videoName + ' (video + audio)';
+                        } else {
+                            label.textContent = videoName + ' + ' + streamName;
+                        }
+                    }
+                } else {
+                    // Multi-track: add audio to pre-created audio element
+                    const audioEl = viewer.audioElements[viewer.audioIndex];
+                    if (audioEl) {
+                        if (!audioEl.srcObject) {
+                            audioEl.srcObject = new MediaStream();
+                        }
+                        audioEl.srcObject.addTrack(event.track);
+                        // Add label
+                        const label = document.createElement('span');
+                        label.classList.add('track-label');
+                        label.textContent = streamName.toLowerCase().includes('audio') ? streamName : streamName + ' (audio)';
+                        audioEl.parentElement.insertBefore(label, audioEl);
+                        viewer.audioIndex++;
+                    }
                 }
-                if (!videoElement) {
-                    videoElement = document.createElement('video');
-                    videoElement.autoplay = true;
-                    videoElement.setAttribute('playsinline', '');
-                    videoElement.controls = true;
-                    container = document.createElement('div');
-                    container.classList.add('video-container');
-                    remoteViewContainer.appendChild(container);
-                }
-            } else {
-                videoElement = document.createElement('video');
-                videoElement.autoplay = true;
-                videoElement.setAttribute('playsinline', '');
-                videoElement.controls = true;
-
-                container = document.createElement('div');
-                container.classList.add('video-container');
-                remoteViewContainer.appendChild(container);
+                return;
             }
 
-            const trackLabel = document.createElement('span');
-            trackLabel.classList.add('track-label');
-            trackLabel.textContent = event.streams[0]?.id || event.track.label || event.track.id;
-            container.insertBefore(trackLabel, container.firstChild);
-            container.appendChild(videoElement);
+            // Video track
+            const videoEl = viewer.videoElements[viewer.videoIndex];
+            if (!videoEl) {
+                console.warn('[VIEWER] No pre-created video element available for track', event.track.id);
+                return;
+            }
 
             const stream = new MediaStream([event.track]);
-            videoElement.srcObject = stream;
+            videoEl.srcObject = stream;
 
-            viewer.remoteViews.push(videoElement);
+            // Add label
+            const label = document.createElement('span');
+            label.classList.add('track-label');
+            label.textContent = streamName;
+            videoEl.parentElement.insertBefore(label, videoEl);
+
+            viewer.remoteViews.push(videoEl);
             viewer.remoteStreams.push(stream);
-
-            // If this is the first video and audio arrived earlier (temporary <audio> element),
-            // move audio into this <video> element for the combined 1V+1A experience.
-            if (viewer.remoteViews.length === 1 && viewer.audioElement) {
-                viewer.audioElement.srcObject.getTracks().forEach((track) => {
-                    stream.addTrack(track);
-                });
-                const audioStreamName = viewer.audioTrackLabel || 'audio';
-                const videoStreamName = trackLabel.textContent;
-                if (audioStreamName === videoStreamName) {
-                    trackLabel.textContent = videoStreamName + ' (video + audio)';
-                } else {
-                    trackLabel.textContent = videoStreamName + ' + ' + audioStreamName;
-                }
-                viewer.audioElement.parentElement.remove();
-                viewer.audioElement = null;
-            }
+            viewer.videoIndex++;
 
             // Attach time-to-first-frame listener on the first video track
-            if (viewer.remoteViews.length === 1) {
-                videoElement.addEventListener('loadeddata', viewer.loadedDataCallback);
+            if (viewer.videoIndex === 1) {
+                videoEl.addEventListener('loadeddata', viewer.loadedDataCallback);
             }
 
             if (formValues.enableDQPmetrics && initialDate === 0) {
                 initialDate = new Date();
             }
 
-            console.log('[VIEWER] Now displaying', viewer.remoteViews.length, 'video track(s)');
+            console.log('[VIEWER] Now displaying', viewer.videoIndex, 'video track(s)');
         });
 
         console.log('[VIEWER] Starting viewer connection');
@@ -1020,7 +998,7 @@ function stopViewer() {
         }
 
         if (viewer.remoteStreams) {
-            viewer.remoteStreams.forEach(stream => stream.getTracks().forEach(track => track.stop()));
+            viewer.remoteStreams.forEach((stream) => stream.getTracks().forEach((track) => track.stop()));
             viewer.remoteStreams = null;
         }
 
@@ -1034,22 +1012,31 @@ function stopViewer() {
         }
 
         if (viewer.remoteViews) {
-            viewer.remoteViews.forEach(view => {
+            viewer.remoteViews.forEach((view) => {
                 view.removeEventListener('loadeddata', viewer.loadedDataCallback);
                 view.srcObject = null;
             });
             viewer.remoteViews = null;
         }
 
-        if (viewer.audioElement) {
-            viewer.audioElement.srcObject?.getTracks().forEach(track => track.stop());
-            viewer.audioElement.srcObject = null;
-            viewer.audioElement = null;
+        if (viewer.videoElements) {
+            viewer.videoElements.forEach((el) => { el.srcObject = null; });
+            viewer.videoElements = null;
+        }
+
+        if (viewer.audioElements) {
+            viewer.audioElements.forEach((el) => {
+                el.srcObject?.getTracks().forEach((track) => track.stop());
+                el.srcObject = null;
+            });
+            viewer.audioElements = null;
         }
 
         if (viewer.remoteViewContainer) {
             viewer.remoteViewContainer.innerHTML = '<div class="video-container"><video class="remote-view" autoplay playsinline controls></video></div>';
         }
+
+        viewer.viewInitialized = false;
 
         if (viewer.dataChannel) {
             viewer.dataChannel = null;

--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -764,6 +764,15 @@ async function startViewer(localView, remoteViewContainer, formValues, onStatsRe
             console.debug('SDP answer:', answer);
             metrics.viewer.offAnswerTime.endTime = Date.now();
             await viewer.peerConnection.setRemoteDescription(answer);
+
+            // Log transceiver directions after SDP answer is applied
+            if (formValues.receiveMultiTrack) {
+                viewer.peerConnection.getTransceivers().forEach(t => {
+                    if (t.currentDirection === 'inactive') {
+                        console.debug(`[VIEWER] Transceiver mid=${t.mid} (${t.receiver.track.kind}) is inactive - remote peer did not send on this m-line`);
+                    }
+                });
+            }
         });
 
         viewer.signalingClient.on('iceCandidate', candidate => {

--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -769,7 +769,7 @@ async function startViewer(localView, remoteViewContainer, formValues, onStatsRe
             if (formValues.receiveMultiTrack) {
                 viewer.peerConnection.getTransceivers().forEach(t => {
                     if (t.currentDirection === 'inactive') {
-                        console.debug(`[VIEWER] Transceiver mid=${t.mid} (${t.receiver.track.kind}) is inactive - remote peer did not send on this m-line`);
+                        console.warn(`[VIEWER] Transceiver mid=${t.mid} (${t.receiver.track.kind}) is inactive - remote peer did not send on this m-line`);
                     }
                 });
             }
@@ -827,7 +827,8 @@ async function startViewer(localView, remoteViewContainer, formValues, onStatsRe
             printPeerConnectionStateInfo(event, '[VIEWER]');
         });
 
-        // As remote tracks are received, add them to the remote view
+        // As remote tracks are received, add them to the remote view.
+        // Note: track events fire sequentially on the JS event loop (single-threaded) — no race conditions.
         viewer.peerConnection.addEventListener('track', event => {
             console.log(
                 '[VIEWER] Received',
@@ -842,13 +843,7 @@ async function startViewer(localView, remoteViewContainer, formValues, onStatsRe
 
             if (event.track.kind !== 'video') {
                 // Single video track: attach audio directly to the video element (1V+1A backwards compat)
-                if (viewer.remoteViews.length <= 1 && !viewer.audioElement) {
-                    // If audio arrives before video, buffer the track to attach once video arrives
-                    if (viewer.remoteViews.length === 0) {
-                        viewer.pendingAudioTrack = event.track;
-                        viewer.pendingAudioStreamName = event.streams[0]?.id || event.track.label || event.track.id;
-                        return;
-                    }
+                if (viewer.remoteViews.length === 1 && !viewer.audioElement) {
                     viewer.remoteViews[0].srcObject.addTrack(event.track);
                     const videoLabel = viewer.remoteViews[0].parentElement.querySelector('.track-label');
                     const audioStreamName = event.streams[0]?.id || event.track.label || event.track.id;
@@ -969,21 +964,21 @@ async function startViewer(localView, remoteViewContainer, formValues, onStatsRe
             viewer.remoteViews.push(videoElement);
             viewer.remoteStreams.push(stream);
 
-            // If audio arrived before this first video, attach it now
-            if (viewer.remoteViews.length === 1 && viewer.pendingAudioTrack) {
-                stream.addTrack(viewer.pendingAudioTrack);
-                viewer.audioTrackLabel = viewer.pendingAudioStreamName;
-                const label = container.querySelector('.track-label');
-                if (label) {
-                    const videoStreamName = label.textContent;
-                    if (viewer.pendingAudioStreamName === videoStreamName) {
-                        label.textContent = videoStreamName + ' (video + audio)';
-                    } else {
-                        label.textContent = videoStreamName + ' + ' + viewer.pendingAudioStreamName;
-                    }
+            // If this is the first video and audio arrived earlier (temporary <audio> element),
+            // move audio into this <video> element for the combined 1V+1A experience.
+            if (viewer.remoteViews.length === 1 && viewer.audioElement) {
+                viewer.audioElement.srcObject.getTracks().forEach((track) => {
+                    stream.addTrack(track);
+                });
+                const audioStreamName = viewer.audioTrackLabel || 'audio';
+                const videoStreamName = trackLabel.textContent;
+                if (audioStreamName === videoStreamName) {
+                    trackLabel.textContent = videoStreamName + ' (video + audio)';
+                } else {
+                    trackLabel.textContent = videoStreamName + ' + ' + audioStreamName;
                 }
-                viewer.pendingAudioTrack = null;
-                viewer.pendingAudioStreamName = null;
+                viewer.audioElement.parentElement.remove();
+                viewer.audioElement = null;
             }
 
             // Attach time-to-first-frame listener on the first video track
@@ -1045,9 +1040,6 @@ function stopViewer() {
             });
             viewer.remoteViews = null;
         }
-
-        viewer.pendingAudioTrack = null;
-        viewer.pendingAudioStreamName = null;
 
         if (viewer.audioElement) {
             viewer.audioElement.srcObject?.getTracks().forEach(track => track.stop());

--- a/examples/viewer.js
+++ b/examples/viewer.js
@@ -256,6 +256,160 @@ let dataChannelLatencyCalcMessage = {
     'lastMessageFromViewerTs': ''
 }
 
+const TrackMode = {
+    NONE: 'None',
+    VIDEO_ONLY: 'VideoOnly',
+    AUDIO_ONLY: 'AudioOnly',
+    AUDIO_VIDEO: 'AudioVideo',
+    MULTI: 'Multi',
+};
+
+/**
+ * Adds an audio track to the appropriate element based on the current track mode.
+ */
+function addAudioTrack(track, streamName) {
+    if (viewer.trackMode === TrackMode.MULTI) {
+        const audioEl = viewer.audioElements[viewer.audioIndex];
+        if (!audioEl) return;
+        if (!audioEl.srcObject) {
+            audioEl.srcObject = new MediaStream();
+        }
+        audioEl.srcObject.addTrack(track);
+        const label = document.createElement('span');
+        label.classList.add('track-label');
+        label.textContent = streamName.toLowerCase().includes('audio') ? streamName : streamName + ' (audio)';
+        audioEl.parentElement.insertBefore(label, audioEl);
+        viewer.audioIndex++;
+    } else if (viewer.trackMode === TrackMode.AUDIO_VIDEO || viewer.trackMode === TrackMode.AUDIO_ONLY) {
+        const videoEl = viewer.videoElements[0];
+        if (!videoEl.srcObject) {
+            videoEl.srcObject = new MediaStream();
+        }
+        videoEl.srcObject.addTrack(track);
+        // In AUDIO_VIDEO mode, addVideoTrack handles the combined label.
+        // In AUDIO_ONLY mode, add a label since there's no video to set one.
+        if (viewer.trackMode === TrackMode.AUDIO_ONLY) {
+            const label = document.createElement('span');
+            label.classList.add('track-label');
+            label.textContent = streamName.toLowerCase().includes('audio') ? streamName : streamName + ' (audio)';
+            videoEl.parentElement.insertBefore(label, videoEl);
+        }
+    } else {
+        console.warn('[VIEWER] Unexpected audio track in', viewer.trackMode, 'mode');
+    }
+}
+
+/**
+ * Adds a video track to the next pre-created video element.
+ * Returns the stream, or null if no element is available.
+ */
+function addVideoTrack(track, streamName) {
+    const videoEl = viewer.videoElements[viewer.videoIndex];
+    if (!videoEl) {
+        console.warn('[VIEWER] No pre-created video element available for track', track.id);
+        return;
+    }
+
+    if (videoEl.srcObject) {
+        videoEl.srcObject.addTrack(track);
+    } else {
+        videoEl.srcObject = new MediaStream([track]);
+    }
+
+    const label = document.createElement('span');
+    label.classList.add('track-label');
+    if (viewer.trackMode === TrackMode.AUDIO_VIDEO) {
+        label.textContent = streamName + ' (video + audio)';
+    } else {
+        label.textContent = streamName;
+    }
+    videoEl.parentElement.insertBefore(label, videoEl);
+
+    viewer.remoteViews.push(videoEl);
+    viewer.remoteStreams.push(videoEl.srcObject);
+    viewer.videoIndex++;
+}
+
+/**
+ * Pre-creates DOM elements for remote tracks based on the negotiated SDP answer.
+ * Called on first "ontrack" event, when transceiver directions are known.
+ *
+ * Display logic:
+ *   1V + 1A (or less): single <video> element handles both.
+ *   Otherwise: each track gets its own element.
+ */
+function initRemoteTrackViews(remoteViewContainer, formValues) {
+    const activeTransceivers = viewer.peerConnection.getTransceivers().filter(
+        (t) => t.currentDirection === 'recvonly' || t.currentDirection === 'sendrecv',
+    );
+    const expectedVideoCount = activeTransceivers.filter((t) => t.receiver.track.kind === 'video').length;
+    const expectedAudioCount = activeTransceivers.filter((t) => t.receiver.track.kind === 'audio').length;
+    console.log(`[VIEWER] Expecting ${expectedVideoCount} video + ${expectedAudioCount} audio track(s) from remote`);
+
+    if (expectedVideoCount > 1 || expectedAudioCount > 1) {
+        viewer.trackMode = TrackMode.MULTI;
+    } else if (expectedVideoCount === 1 && expectedAudioCount === 1) {
+        viewer.trackMode = TrackMode.AUDIO_VIDEO;
+    } else if (expectedVideoCount === 1) {
+        viewer.trackMode = TrackMode.VIDEO_ONLY;
+    } else if (expectedAudioCount === 1) {
+        viewer.trackMode = TrackMode.AUDIO_ONLY;
+    } else {
+        viewer.trackMode = TrackMode.NONE;
+    }
+    console.log(`[VIEWER] Receiving track mode: ${viewer.trackMode}`);
+
+    viewer.videoElements = [];
+    viewer.audioElements = [];
+    remoteViewContainer.innerHTML = '';
+
+    if (viewer.trackMode !== TrackMode.MULTI) {
+        const container = document.createElement('div');
+        container.classList.add('video-container');
+        const videoEl = document.createElement('video');
+        videoEl.autoplay = true;
+        videoEl.setAttribute('playsinline', '');
+        videoEl.controls = true;
+        container.appendChild(videoEl);
+        remoteViewContainer.appendChild(container);
+        viewer.videoElements.push(videoEl);
+    } else {
+        for (let i = 0; i < expectedVideoCount; i++) {
+            const container = document.createElement('div');
+            container.classList.add('video-container');
+            const videoEl = document.createElement('video');
+            videoEl.autoplay = true;
+            videoEl.setAttribute('playsinline', '');
+            videoEl.controls = true;
+            container.appendChild(videoEl);
+            remoteViewContainer.appendChild(container);
+            viewer.videoElements.push(videoEl);
+        }
+        for (let i = 0; i < expectedAudioCount; i++) {
+            const container = document.createElement('div');
+            container.classList.add('video-container');
+            const audioEl = document.createElement('audio');
+            audioEl.autoplay = true;
+            audioEl.controls = true;
+            container.appendChild(audioEl);
+            remoteViewContainer.appendChild(container);
+            viewer.audioElements.push(audioEl);
+        }
+    }
+
+    viewer.videoIndex = 0;
+    viewer.audioIndex = 0;
+
+    // Log inactive transceivers as warnings
+    if (formValues.receiveMultiTrack) {
+        viewer.peerConnection.getTransceivers().forEach((t) => {
+            if (t.currentDirection === 'inactive') {
+                console.warn(`[VIEWER] Transceiver mid=${t.mid} (${t.receiver.track.kind}) is inactive - remote peer did not send on this m-line`);
+            }
+        });
+    }
+}
+
 async function startViewer(localView, remoteViewContainer, formValues, onStatsReport, remoteMessage) {
     try {
         console.log('[VIEWER] Client id is:', formValues.clientId);
@@ -836,132 +990,24 @@ async function startViewer(localView, remoteViewContainer, formValues, onStatsRe
                 event.track.id,
             );
 
-            // Lazy init: pre-create all DOM elements on the first ontrack event.
-            // At this point, setRemoteDescription has completed and transceivers have currentDirection set.
+            // Pre-create all DOM elements on the first ontrack event.
             if (!viewer.viewInitialized) {
                 viewer.viewInitialized = true;
-                const activeTransceivers = viewer.peerConnection.getTransceivers().filter(
-                    (t) => t.currentDirection === 'recvonly' || t.currentDirection === 'sendrecv',
-                );
-                viewer.expectedVideoCount = activeTransceivers.filter((t) => t.receiver.track.kind === 'video').length;
-                const expectedAudioCount = activeTransceivers.filter((t) => t.receiver.track.kind === 'audio').length;
-                console.log(`[VIEWER] Expecting ${viewer.expectedVideoCount} video + ${expectedAudioCount} audio track(s) from remote`);
-
-                viewer.videoElements = [];
-                viewer.audioElements = [];
-                remoteViewContainer.innerHTML = '';
-
-                if (viewer.expectedVideoCount <= 1 && expectedAudioCount <= 1) {
-                    // Single combined <video> element for 1V+1A
-                    const container = document.createElement('div');
-                    container.classList.add('video-container');
-                    const videoEl = document.createElement('video');
-                    videoEl.autoplay = true;
-                    videoEl.setAttribute('playsinline', '');
-                    videoEl.controls = true;
-                    container.appendChild(videoEl);
-                    remoteViewContainer.appendChild(container);
-                    viewer.videoElements.push(videoEl);
-                } else {
-                    // Multi-track: one <video> per video track, one <audio> per audio track
-                    for (let i = 0; i < viewer.expectedVideoCount; i++) {
-                        const container = document.createElement('div');
-                        container.classList.add('video-container');
-                        const videoEl = document.createElement('video');
-                        videoEl.autoplay = true;
-                        videoEl.setAttribute('playsinline', '');
-                        videoEl.controls = true;
-                        container.appendChild(videoEl);
-                        remoteViewContainer.appendChild(container);
-                        viewer.videoElements.push(videoEl);
-                    }
-                    for (let i = 0; i < expectedAudioCount; i++) {
-                        const container = document.createElement('div');
-                        container.classList.add('video-container');
-                        const audioEl = document.createElement('audio');
-                        audioEl.autoplay = true;
-                        audioEl.controls = true;
-                        container.appendChild(audioEl);
-                        remoteViewContainer.appendChild(container);
-                        viewer.audioElements.push(audioEl);
-                    }
-                }
-
-                viewer.videoIndex = 0;
-                viewer.audioIndex = 0;
-
-                // Log inactive transceivers as warnings
-                if (formValues.receiveMultiTrack) {
-                    viewer.peerConnection.getTransceivers().forEach((t) => {
-                        if (t.currentDirection === 'inactive') {
-                            console.warn(`[VIEWER] Transceiver mid=${t.mid} (${t.receiver.track.kind}) is inactive - remote peer did not send on this m-line`);
-                        }
-                    });
-                }
+                initRemoteTrackViews(remoteViewContainer, formValues);
             }
 
             const streamName = event.streams[0]?.id || event.track.label || event.track.id;
 
-            if (event.track.kind !== 'video') {
-                if (viewer.expectedVideoCount <= 1) {
-                    // 1V+1A: add audio to the single video element
-                    const videoEl = viewer.videoElements[0];
-                    if (!videoEl.srcObject) {
-                        videoEl.srcObject = new MediaStream();
-                    }
-                    videoEl.srcObject.addTrack(event.track);
-                    // Update label
-                    const label = videoEl.parentElement.querySelector('.track-label');
-                    if (label) {
-                        const videoName = label.textContent;
-                        if (streamName === videoName) {
-                            label.textContent = videoName + ' (video + audio)';
-                        } else {
-                            label.textContent = videoName + ' + ' + streamName;
-                        }
-                    }
-                } else {
-                    // Multi-track: add audio to pre-created audio element
-                    const audioEl = viewer.audioElements[viewer.audioIndex];
-                    if (audioEl) {
-                        if (!audioEl.srcObject) {
-                            audioEl.srcObject = new MediaStream();
-                        }
-                        audioEl.srcObject.addTrack(event.track);
-                        // Add label
-                        const label = document.createElement('span');
-                        label.classList.add('track-label');
-                        label.textContent = streamName.toLowerCase().includes('audio') ? streamName : streamName + ' (audio)';
-                        audioEl.parentElement.insertBefore(label, audioEl);
-                        viewer.audioIndex++;
-                    }
-                }
+            if (event.track.kind === 'audio') {
+                addAudioTrack(event.track, streamName);
                 return;
             }
 
-            // Video track
-            const videoEl = viewer.videoElements[viewer.videoIndex];
-            if (!videoEl) {
-                console.warn('[VIEWER] No pre-created video element available for track', event.track.id);
-                return;
-            }
-
-            const stream = new MediaStream([event.track]);
-            videoEl.srcObject = stream;
-
-            // Add label
-            const label = document.createElement('span');
-            label.classList.add('track-label');
-            label.textContent = streamName;
-            videoEl.parentElement.insertBefore(label, videoEl);
-
-            viewer.remoteViews.push(videoEl);
-            viewer.remoteStreams.push(stream);
-            viewer.videoIndex++;
+            addVideoTrack(event.track, streamName);
 
             // Attach time-to-first-frame listener on the first video track
             if (viewer.videoIndex === 1) {
-                videoEl.addEventListener('loadeddata', viewer.loadedDataCallback);
+                viewer.videoElements[0].addEventListener('loadeddata', viewer.loadedDataCallback);
             }
 
             if (formValues.enableDQPmetrics && initialDate === 0) {


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- The viewer example now supports receiving and displaying up to 4 video tracks + 1 audio track over a single PeerConnection (multi-track), gated behind a "Receive Multi-Track" checkbox (off by default for backwards compatibility).
- Added CSS grid layout (`.remote-views`) to dynamically arrange multiple video elements.
- Added track labels above each video/audio element showing the stream name.
- When "Receive Multi-Track" is checked, adds 4 recvonly video transceivers to the SDP offer so the remote peer knows we can accept multiple video tracks.


| 1V + 1A | 4V + 1A |
|-------|-------|
| <img width="1161" height="675" alt="image" src="https://github.com/user-attachments/assets/c43aa1f3-4508-49c6-abc9-237250aa98fd" /> |  <img width="1186" height="713" alt="image" src="https://github.com/user-attachments/assets/c20f0680-6097-410b-b535-d2bac7a140c1" /> |




*Why was it changed?*
- To demonstrate multi-track WebRTC capability where a single PeerConnection can carry multiple video streams (e.g., IoT robot with multiple cameras) without requiring separate signaling channels and TURN allocations per track.
- Provides a reference implementation for customers who want to receive multiple video tracks in their viewer applications.
- The extra transceivers are opt-in to avoid inflating the SDP size for existing users who may hit KVS Signaling service limits.

*How was it changed?*
- **HTML (`index.html`)**: Replaced the single `<video>` element with a `.remote-views` grid container wrapping a placeholder `<video>` (preserves the blank-screen initial state). Added "Receive Multi-Track (P2P viewer only)" checkbox under Tracks section.
- **CSS (`app.css`)**: Added grid layout for `.remote-views`, styling for `.track-label` bars displayed above each track, and width constraints for `<audio>` elements.
- **JS (`app.js`)**: Added `receiveMultiTrack` to form values and localStorage persistence fields.
- **JS (`viewer.js`)**:
  - Gated `addTransceiver('video', { direction: 'recvonly' })` behind `formValues.receiveMultiTrack`. The answerer (C SDK master) cannot add new m-lines — it can only send on m-lines present in the offer, so these must be in the offer upfront.
  - Rewrote the `track` event handler to:
    - **1V+1A (backwards compatible)**: Attach audio directly to the single `<video>` element. Label shows `streamName (video + audio)`.
    - **Multi-video**: Create separate `<video>` elements per track in the grid. Audio gets its own `<audio>` element.
    - **Transition**: When a 2nd video track arrives, audio is moved from the first `<video>` to a separate `<audio>` element.
  - Audio label logic: appends `(audio)` only if the stream name doesn't already contain "audio".
  - Updated `stopViewer()` to iterate and clean up all video/audio elements and streams.

*What testing was done for the changes?*
- Tested 1V+1A (single track) mode with checkbox unchecked - verified backwards compatibility with existing master peer sending one video + one audio track on the same stream. Single `<video>` element renders both, label shows `myKvsVideoStream (video + audio)`. SDP offer contains only 1 video m-line (no inflation).
- Tested 1V+1A mode with checkbox checked - same behavior as above, SDP has 4 video m-lines but unused ones come back as `inactive`.
- Tested 4V+1A (multi-track) mode with checkbox checked - verified 4 video tracks render in a grid layout with individual stream labels (`myKvsVideoStream0`-`3`), audio renders in a separate labeled element (`myKvsAudioStream`).
- Verified `stopViewer()` properly cleans up all dynamically created elements.
- Verified iOS Safari compatibility by using `setAttribute('playsinline', '')` for dynamically created video elements.
- Verified audio element does not overflow its container.
- Tested reconnection (stop/start viewer) - DOM properly resets.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
