### PR TITLE
bump jquery version to 3.7.1

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
     <link rel="stylesheet" href="loader.css">
     <link rel="stylesheet" href="./app.css">
-    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.7.1.slim.min.js"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.bundle.min.js"></script>
     <script src="https://unpkg.com/@ungap/url-search-params"></script>
     <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*Description of changes:*
- Updated JQuery version used by test page from 3.3.1 to 3.7.1

*Testing*
- Manually tested JS <-> JS and JS <-> C.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.