### PR TITLE
Bump websocket-driver from 0.7.4 to 0.7.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23355,9 +23355,9 @@
             }
         },
         "node_modules/websocket-driver": {
-            "version": "0.7.4",
-            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-            "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+            "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {


### PR DESCRIPTION
*Issue #, if available:*
- https://advisories.gitlab.com/npm/websocket-driver/CVE-2026-54466/

*Description of changes:*
- Bumped websocket-driver version to latest


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
