### PR TITLE
Samples: Offer RTX and H.265 by default

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -19,9 +19,10 @@ const allACodecs = RTCRtpSender.getCapabilities('audio').codecs;
 const uniqueVMimeTypes = [...new Set(allVCodecs.map((codec) => codec.mimeType))].sort();
 const uniqueAMimeTypes = [...new Set(allACodecs.map((codec) => codec.mimeType))].sort();
 
-// include video/rtx so RTX (RFC 4588 retransmission) is enabled when codec preferences are set
+// include video/rtx so RTX (RFC 4588 retransmission) is enabled when codec preferences are set,
+// and video/H265 so HEVC is offered by default where the browser supports it
 const DEFAULT_CODECS = {
-    video: ['video/H264', 'video/rtx'].sort(),
+    video: ['video/H264', 'video/H265', 'video/rtx'].sort(),
     audio: ['audio/opus'].sort(),
 };
 

--- a/examples/app.js
+++ b/examples/app.js
@@ -19,9 +19,9 @@ const allACodecs = RTCRtpSender.getCapabilities('audio').codecs;
 const uniqueVMimeTypes = [...new Set(allVCodecs.map((codec) => codec.mimeType))].sort();
 const uniqueAMimeTypes = [...new Set(allACodecs.map((codec) => codec.mimeType))].sort();
 
-// Default-enabled codecs
+// include video/rtx so RTX (RFC 4588 retransmission) is enabled when codec preferences are set
 const DEFAULT_CODECS = {
-    video: ['video/H264'].sort(),
+    video: ['video/H264', 'video/rtx'].sort(),
     audio: ['audio/opus'].sort(),
 };
 
@@ -555,16 +555,16 @@ async function printPeerConnectionStateInfo(event, logPrefix, remoteClientId) {
                     logSelectedCandidate();
                 } else {
                     // Find nominated candidate pair
-                    const nominatedPair = Array.from(stats.values()).find(report => 
-                    report.type === 'candidate-pair' && 
+                    const nominatedPair = Array.from(stats.values()).find(report =>
+                    report.type === 'candidate-pair' &&
                     report.nominated === true
                     );
-            
+
                     if (nominatedPair) {
-                        // Get local and remote candidate detailsl;                     
+                        // Get local and remote candidate detailsl;
                         const localCandidate = stats.get(nominatedPair.localCandidateId);
                         const remoteCandidate = stats.get(nominatedPair.remoteCandidateId);
-                        
+
                         if (localCandidate && remoteCandidate) {
                             console.debug(`Chosen candidate pair (${trackType || 'unknown'}):`, {
                                 local: {
@@ -1097,7 +1097,7 @@ $('#codec-filter-toggle').on('change', (event) => {
 
 $(document).ready(() => {
     loadCodecPreferences();
-    
+
     // click start based on the url params
     if (urlParams.has('view')) {
         const viewMode = urlParams.get('view');


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Added `video/rtx` and `video/H265` to the sample app's default video codec list (`DEFAULT_CODECS.video` in `examples/app.js`), alongside `video/H264`.

*Why was it changed?*
- **H.265** If the remote peer (e.g. a C SDK master) only adds **H.265** transceivers and the viewer's offer (this) doesn't list H.265, that transceiver negotiates to **`inactive`**. The `RTCPeerConnection` still establishes and ICE/DTLS succeed, which may be confusing.
- **RTX ** Without `video/rtx` in the offer, RTX is stripped from codec preferences, so lost/NACKed packets fall back to a "plain resend" on the primary SSRC instead of a proper RFC 4588 RTX stream — no clean separation of retransmitted packets.
  - The sample builds `setCodecPreferences()` from a filtered `getCapabilities('video').codecs` list. `video/rtx` was not in the default-enabled set, so it was filtered out of the codec preferences the browser sent. That stripped the `a=rtpmap:<pt> rtx/90000` + `a=fmtp:<pt> apt=<...>` lines from the viewer's offer, so RTX (RFC 4588 retransmission) was never negotiated - NACKed packets fell back to plain resend instead of a proper RTX stream.

*How was it changed?*
- Added the two codecs to the defaults array
  - This is a safe change on browsers/platforms without H.265. `DEFAULT_CODECS.video` is only ever intersected with what `RTCRtpSender.getCapabilities('video')` actually reports: no H.265 capability means no H.265 checkbox is rendered and `getCodecFilters()` contributes no H.265 payload type, so the offer is byte-for-byte identical to the H.264 + RTX default. Nothing is forced into the SDP that the browser can't do, and negotiation is unchanged.

*What testing was done for the changes?*
- Confirmed `video/rtx` is available and advertised by default across browsers (`RTCRtpSender.getCapabilities('video').codecs` includes `{ clockRate: 90000, mimeType: 'video/rtx' }` in Chrome, Firefox, Safari, and Edge).
- Inspected the viewer's generated SDP offer with the change applied. With `video/rtx` enabled (default), each video codec now carries its RTX payload type and `apt=` binding, and the video m-line payload list includes the RTX PTs. Unchecking `video/rtx` in the UI removes them again (explicit-disable path still works).

**Before (RTX not in the default set - stripped from the offer):**

```
m=video 9 UDP/TLS/RTP/SAVPF 103 107 109 115 117 39 119
...
a=rtpmap:103 H264/90000
a=rtcp-fb:103 nack
a=rtcp-fb:103 nack pli
a=fmtp:103 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f
a=rtpmap:107 H264/90000
...
```
No `rtx/90000` / `apt=` lines - RTX is never negotiated; NACKs fall back to plain resend.

**After (`video/rtx` enabled by default):**

```
m=video 9 UDP/TLS/RTP/SAVPF 103 104 107 108 109 114 115 116 117 118 39 40 119 120
...
a=rtpmap:103 H264/90000
a=rtcp-fb:103 nack
a=rtcp-fb:103 nack pli
a=fmtp:103 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f
a=rtpmap:104 rtx/90000
a=fmtp:104 apt=103
a=rtpmap:107 H264/90000
...
```
Each media PT now has a paired RTX PT (`104` -> `apt=103`, `108` -> `apt=107`, ...); the master and viewer negotiate a proper RFC 4588 RTX stream.

**In the usual case (1 video + 1 audio m-line), on Chrome 151, the new default is well within every limit:**

| Config | attrs / video m-line | base64 signaling bytes | m-lines |
|---|---|---|---|
| H.264 + Opus (old default) | 88 | 5,564 | 2 |
| **H.264 + H.265 + RTX + Opus (new default)** | **132** | **7,048** | 2 |

vs. the C SDK caps of **256 attributes/m-line**, **18,750 B** default signaling buffer (`MAX_SIGNALING_MESSAGE_LEN`), and **6 m-lines**. The new default uses roughly half the attribute budget and a third of the signaling buffer — plenty of headroom. (recvonly is smaller still: 126 attrs / 6,452 B.)

Codec filtering is what keeps this bounded, and it is **on by default** in the sample. The 256-attribute overflow from WebRTC-C-2375 only reproduces with the codec filter **disabled** (unfiltered offers reach 284 attributes).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
