### PR TITLE
ci: retarget Dependabot PRs via REST API instead of gh pr edit

### DIFF
--- a/.github/workflows/retarget-dependabot-to-develop.yml
+++ b/.github/workflows/retarget-dependabot-to-develop.yml
@@ -14,7 +14,24 @@ jobs:
       contents: read
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PR_URL: ${{ github.event.pull_request.html_url }}
+      GH_REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
+      # Use the REST API (PATCH /pulls/{n}) instead of `gh pr edit --base`.
+      # `gh pr edit --base` goes through the GraphQL updatePullRequest mutation,
+      # which has been failing consistently with "Something went wrong while
+      # executing your query" when changing a PR base from master to develop.
+      # The REST endpoint is a different code path and avoids that failure.
+      # The loop adds a small retry to absorb genuinely transient errors.
       - name: Change base branch to develop
-        run: gh pr edit "$PR_URL" --base develop
+        run: |
+          for attempt in 1 2 3; do
+            if gh api --method PATCH "repos/${GH_REPO}/pulls/${PR_NUMBER}" -f base=develop; then
+              echo "Retargeted PR #${PR_NUMBER} to develop"
+              exit 0
+            fi
+            echo "Attempt ${attempt} to retarget PR #${PR_NUMBER} failed; retrying in $((attempt * 5))s..."
+            sleep $((attempt * 5))
+          done
+          echo "Failed to retarget PR #${PR_NUMBER} to develop after 3 attempts"
+          exit 1

--- a/.github/workflows/retarget-dependabot-to-develop.yml
+++ b/.github/workflows/retarget-dependabot-to-develop.yml
@@ -26,12 +26,16 @@ jobs:
       - name: Change base branch to develop
         run: |
           for attempt in 1 2 3; do
-            if gh api --method PATCH "repos/${GH_REPO}/pulls/${PR_NUMBER}" -f base=develop; then
+            # Capture stdout+stderr and the HTTP status so a failure logs *why*
+            # (e.g. the API error message / response body), not just that it failed.
+            if response=$(gh api --method PATCH "repos/${GH_REPO}/pulls/${PR_NUMBER}" \
+                -f base=develop --include 2>&1); then
               echo "Retargeted PR #${PR_NUMBER} to develop"
               exit 0
             fi
-            echo "Attempt ${attempt} to retarget PR #${PR_NUMBER} failed; retrying in $((attempt * 5))s..."
+            echo "Attempt ${attempt} to retarget PR #${PR_NUMBER} failed. gh api response:"
+            echo "${response}"
             sleep $((attempt * 5))
           done
-          echo "Failed to retarget PR #${PR_NUMBER} to develop after 3 attempts"
+          echo "Failed to retarget PR #${PR_NUMBER} to develop after 3 attempts (see gh api response above)"
           exit 1


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*Description of changes:*
_What was changed?_

- Replaced the retarget step in `.github/workflows/retarget-dependabot-to-develop.yml` that changes a Dependabot PR's base branch from `master` to `develop`.
- Old: `gh pr edit "$PR_URL" --base develop` (GitHub GraphQL API).
- New: `gh api --method PATCH repos/{owner}/{repo}/pulls/{number} -f base=develop` (GitHub REST API), wrapped in a 3-attempt retry loop.

_Why was it changed?_

- The `gh pr edit --base` command calls GitHub's GraphQL `updatePullRequest` mutation, which has been failing consistently with `GraphQL: Something went wrong while executing your query`.
- As a result, Dependabot security-update PRs (which always open against the default branch `master`, ignoring `target-branch: develop`) were never retargeted, got stuck on `master`, and then failed the `master`-only version-check gate.
- The failure is server-side and deterministic — it reproduces even from an admin account — so retrying the same GraphQL call does not help. Routing the same action through a different backend (REST) avoids the broken code path.

_How was it changed?_

- Swapped the GraphQL-backed `gh pr edit` call for the equivalent REST endpoint `PATCH /repos/{owner}/{repo}/pulls/{number}` via `gh api`.
- Added a 3-attempt retry with backoff to absorb genuinely transient errors (not the fix for the GraphQL issue itself — the mechanism swap is).
- Updated the job env to pass `GH_REPO` and `PR_NUMBER` (the REST call needs the repo and PR number) in place of `PR_URL`.

_What testing was done for the changes?_

- Reproduced the failure: `gh pr edit --base develop` on a stuck PR returned the GraphQL error even with admin credentials.
- Verified the fix: the REST call (`gh api --method PATCH .../pulls/{n} -f base=develop`) successfully retargeted the same PR from `master` to `develop`.
- Applied the same REST call to the full backlog — all 13 stuck Dependabot PRs were retargeted to `develop` successfully.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
